### PR TITLE
Update package versions in Directory.Packages.props

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -10,31 +10,31 @@
     </PackageVersion>
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="Autofac" Version="8.4.0" />
-    <PackageVersion Include="Avalonia" Version="11.3.5" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.5" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.5" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.5" />
+    <PackageVersion Include="Avalonia" Version="11.3.7" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.7" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.7" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.7" />
     <PackageVersion Include="DryIoc.Dll" Version="5.4.3" />
     <PackageVersion Include="DynamicData" Version="9.4.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
     <PackageVersion Include="Ninject" Version="3.3.6" />
     <PackageVersion Include="ReactiveUI" Version="21.0.1" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.14.0" />
-    <PackageVersion Include="Splat" Version="16.2.1" />
-    <PackageVersion Include="Splat.Autofac" Version="16.2.1" />
-    <PackageVersion Include="Splat.Drawing" Version="16.2.1" />
-    <PackageVersion Include="Splat.DryIoc" Version="16.2.1" />
-    <PackageVersion Include="Splat.Ninject" Version="16.2.1" />
+    <PackageVersion Include="Splat" Version="17.1.1" />
+    <PackageVersion Include="Splat.Autofac" Version="17.1.1" />
+    <PackageVersion Include="Splat.Drawing" Version="17.1.1" />
+    <PackageVersion Include="Splat.DryIoc" Version="17.1.1" />
+    <PackageVersion Include="Splat.Ninject" Version="17.1.1" />
     <PackageVersion Include="stylecop.analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageVersion Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.8" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.9" />
     <PackageVersion Include="NUnit" Version="4.3.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.10.0" />


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the new behavior?**
<!-- If this is a feature change -->

This pull request updates several NuGet package dependencies to their latest patch versions in the `src/Directory.Packages.props` file. These updates help ensure compatibility, security, and access to the latest features and bug fixes.

Dependency version updates:

**Avalonia UI Framework:**
* Upgraded `Avalonia`, `Avalonia.Desktop`, `Avalonia.Fonts.Inter`, and `Avalonia.Themes.Fluent` from version 11.3.5 to 11.3.7.

**Splat Libraries:**
* Upgraded `Splat`, `Splat.Autofac`, `Splat.Drawing`, `Splat.DryIoc`, and `Splat.Ninject` from version 16.2.1 to 17.1.1.

**Microsoft Packages:**
* Upgraded `Microsoft.Extensions.DependencyInjection` from 9.0.8 to 9.0.9.
* Upgraded `System.Text.Json` from 9.0.8 to 9.0.9.

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

