### PR TITLE
fix: subscribe to RoutedViewHost navigation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,9 +416,12 @@ public class AppViewModel : ReactiveObject, IScreen
 {
     public RoutingState Router { get; } = new RoutingState();
 
-    public AppViewModel() => Router.Navigate.Execute(new MyViewModel());
+    public AppViewModel() => _ = Router.Navigate.Execute(new MyViewModel()).Subscribe();
 }
 ```
+
+`ReactiveCommand.Execute` returns a cold observable. Subscribe to or await the result; discarding it does not perform
+the navigation.
 
 ```xml
 <!-- MainWindow.axaml -->

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveCoverageTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveCoverageTests.cs
@@ -219,7 +219,7 @@ public class ReactiveCoverageTests
 
         routedHost.Attach(source);
         routedHost.Attach(source);
-        _ = screen.Router.Navigate.Execute(new VmA(screen));
+        _ = screen.Router.Navigate.Execute(new VmA(screen)).Subscribe();
         routedHost.Router = null;
         routedHost.Detach(source);
 

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveShimFullCoverageTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveShimFullCoverageTests.cs
@@ -708,7 +708,7 @@ public partial class ReactiveShimFullCoverageTests
         try
         {
             routedWindow.Show();
-            _ = screen.Router.Navigate.Execute(new VmA(screen));
+            _ = screen.Router.Navigate.Execute(new VmA(screen)).Subscribe();
             await Assert.That(routedHost.Content).IsTypeOf<ViewA>();
 
             routedHost.Router = null;

--- a/src/tests/ReactiveUI.Avalonia.Tests/Mocks/ViewModels/RoutedViewHostPageViewModel.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/Mocks/ViewModels/RoutedViewHostPageViewModel.cs
@@ -8,6 +8,9 @@ namespace ReactiveUIDemo.ViewModels;
 /// <summary>View model for the routed view host page in the demo application.</summary>
 internal sealed class RoutedViewHostPageViewModel : ReactiveObject, IScreen
 {
+    /// <summary>Observes navigation results without requiring System.Reactive convenience overloads.</summary>
+    private static readonly NavigationObserver Observer = new();
+
     /// <summary>Initializes a new instance of the <see cref="RoutedViewHostPageViewModel"/> class.</summary>
     private RoutedViewHostPageViewModel()
     {
@@ -32,16 +35,33 @@ internal sealed class RoutedViewHostPageViewModel : ReactiveObject, IScreen
     }
 
     /// <summary>Navigates to the Foo view.</summary>
-    internal void ShowFoo() => Router.Navigate.Execute(Foo);
+    internal void ShowFoo() => _ = Router.Navigate.Execute(Foo).Subscribe(Observer);
 
     /// <summary>Navigates to the Bar view.</summary>
-    internal void ShowBar() => Router.Navigate.Execute(Bar);
+    internal void ShowBar() => _ = Router.Navigate.Execute(Bar).Subscribe(Observer);
 
     /// <summary>Initializes routing after construction has completed.</summary>
     private void Initialize()
     {
         Foo = new(this);
         Bar = new(this);
-        _ = Router.Navigate.Execute(Foo);
+        _ = Router.Navigate.Execute(Foo).Subscribe(Observer);
+    }
+
+    /// <summary>Forwards navigation errors while otherwise observing command completion.</summary>
+    private sealed class NavigationObserver : IObserver<IRoutableViewModel>
+    {
+        /// <inheritdoc/>
+        public void OnCompleted()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void OnError(Exception error) => System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(error).Throw();
+
+        /// <inheritdoc/>
+        public void OnNext(IRoutableViewModel value)
+        {
+        }
     }
 }

--- a/src/tests/ReactiveUI.Avalonia.Tests/ViewHostsNavigationTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/ViewHostsNavigationTests.cs
@@ -263,7 +263,7 @@ public class ViewHostsNavigationTests
         try
         {
             window.Show();
-            _ = screen.Router.Navigate.Execute(vm);
+            _ = screen.Router.Navigate.Execute(vm).Subscribe();
 
             await Assert.That(host.Content).IsTypeOf<ViewA>();
             await Assert.That(((IViewFor)host.Content!).ViewModel).IsSameReferenceAs(vm);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix and documentation/test correction for #185 
Closes #185 

## What is the new behavior?

The routing example, routed-host demo fixture, and related tests subscribe to the observable returned by Router.Navigate.Execute(...). The README now explains that ReactiveCommand.Execute is cold and must be subscribed to or awaited.

## What is the current behavior?

The previous example and test/demo call sites discarded the observable returned by Execute, so navigation was never performed and RoutedViewHost remained on its default content.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

## Additional information

Addresses reactiveui/ReactiveUI.Avalonia#185.

No ReactiveUI.Avalonia production-code change is required because the reported behavior is caused by an unexecuted cold navigation observable.

Validation:
- Release solution build passed with warnings treated as errors.
- ReactiveUI.Avalonia.Tests: 162/162 TUnit tests passed on net10.0.
- ReactiveUI.Avalonia.Reactive.Tests: 31/31 TUnit tests passed on net10.0.
- ReactiveUI.Avalonia.DryIoc.Tests: 7/7 TUnit tests passed on net10.0.
- RoutedViewHost coverage: 100% line and branch coverage.