### PR TITLE
feat: add Avalonia showcase and harden integrations

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,93 +3,20 @@ name: Build
 on:
   push:
     branches:
-      - main
-  pull_request:
-
+      - main          # ✅ run on main
+  pull_request:        # (optional) run on PRs targeting any branch
+  
+# Needed so the reusable workflow can optionally delete the temp per-OS artifacts it creates.
 permissions:
   contents: read
+  actions: write
 
 jobs:
-  build-and-test:
-    name: build / ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - windows-latest
-          - ubuntu-latest
-          - macos-latest
-    env:
-      DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE: 1
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          lfs: true
-
-      - name: Setup .NET environment
-        uses: reactiveui/actions-common/.github/actions/dotnet-environment@main
-        with:
-          dotnet-versions: |
-            8.0.x
-            9.0.x
-            10.0.x
-            11.0.x
-          src-folder: src
-          solution-file: ReactiveUI.Avalonia.slnx
-          minver-tag-prefix: v
-          minver-minimum-major-minor: 12.1
-          minver-auto-increment: minor
-          minver-default-pre-release-identifiers: alpha.0
-
-      - name: Build
-        working-directory: src
-        run: dotnet build ReactiveUI.Avalonia.slnx -c Release -warnaserror
-
-      - name: Test with serialized coverage collection
-        working-directory: src
-        run: >
-          dotnet test --solution ReactiveUI.Avalonia.slnx -c Release
-          --max-parallel-test-modules 1
-          --coverage --coverage-output-format cobertura
-          --report-trx --progress off --disable-logo
-
-      - name: Upload coverage
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-${{ runner.os }}
-          path: |
-            src/**/TestResults/**/*.cobertura.xml
-          if-no-files-found: error
-          retention-days: 30
-
-  collect-coverage:
-    name: collect coverage
-    needs: build-and-test
-    if: success()
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download coverage reports
-        uses: actions/download-artifact@v8
-        with:
-          pattern: coverage-*
-          path: .collect
-          merge-multiple: true
-
-      - name: Upload coverage to Codecov
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: |
-          python -m pip install codecov-cli
-          files=$(find .collect -name '*.cobertura.xml' -type f | sed 's/^/--file /' | tr '\n' ' ')
-          if [ -z "$files" ]; then
-            echo 'No Cobertura reports were produced.' >&2
-            exit 1
-          fi
-            codecov-cli upload-coverage --git-service github $files
+  build:
+    uses: reactiveui/actions-common/.github/workflows/workflow-common-setup-and-build.yml@main
+    with:
+      configuration: Release
+      productNamespacePrefix: "ReactiveUI"
+      solutionFile: "ReactiveUI.Avalonia.slnx"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -92,4 +92,4 @@ jobs:
             echo 'No Cobertura reports were produced.' >&2
             exit 1
           fi
-            codecov-cli upload-coverage --git-service github-actions $files
+            codecov-cli upload-coverage --git-service github $files

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,22 +1,95 @@
-﻿name: Build
+name: Build
 
 on:
   push:
     branches:
-      - main          # ✅ run on main
-  pull_request:        # (optional) run on PRs targeting any branch
-  
-# Needed so the reusable workflow can optionally delete the temp per-OS artifacts it creates.
+      - main
+  pull_request:
+
 permissions:
   contents: read
-  actions: write
 
 jobs:
-  build:
-    uses: reactiveui/actions-common/.github/workflows/workflow-common-setup-and-build.yml@main
-    with:
-      configuration: Release
-      productNamespacePrefix: "ReactiveUI"
-      solutionFile: "ReactiveUI.Avalonia.slnx"
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  build-and-test:
+    name: build / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+    env:
+      DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE: 1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - name: Setup .NET environment
+        uses: reactiveui/actions-common/.github/actions/dotnet-environment@main
+        with:
+          dotnet-versions: |
+            8.0.x
+            9.0.x
+            10.0.x
+            11.0.x
+          src-folder: src
+          solution-file: ReactiveUI.Avalonia.slnx
+          minver-tag-prefix: v
+          minver-minimum-major-minor: 12.1
+          minver-auto-increment: minor
+          minver-default-pre-release-identifiers: alpha.0
+
+      - name: Build
+        working-directory: src
+        run: dotnet build ReactiveUI.Avalonia.slnx -c Release -warnaserror
+
+      - name: Test with serialized coverage collection
+        working-directory: src
+        run: >
+          dotnet test --solution ReactiveUI.Avalonia.slnx -c Release
+          --max-parallel-test-modules 1
+          --coverage --coverage-output-format cobertura
+          --report-trx --progress off --disable-logo
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-${{ runner.os }}
+          path: |
+            src/**/TestResults/**/*.cobertura.xml
+          if-no-files-found: error
+          retention-days: 30
+
+  collect-coverage:
+    name: collect coverage
+    needs: build-and-test
+    if: success()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download coverage reports
+        uses: actions/download-artifact@v8
+        with:
+          pattern: coverage-*
+          path: .collect
+          merge-multiple: true
+
+      - name: Upload coverage to Codecov
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          python -m pip install codecov-cli
+          files=$(find .collect -name '*.cobertura.xml' -type f | sed 's/^/--file /' | tr '\n' ' ')
+          if [ -z "$files" ]; then
+            echo 'No Cobertura reports were produced.' >&2
+            exit 1
+          fi
+          codecov-cli upload-coverage $files

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -92,4 +92,4 @@ jobs:
             echo 'No Cobertura reports were produced.' >&2
             exit 1
           fi
-          codecov-cli upload-coverage $files
+            codecov-cli upload-coverage --git-service github-actions $files

--- a/README.md
+++ b/README.md
@@ -27,7 +27,19 @@ Install the packages that match your preferred dependency injection container. T
   - [![ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection](https://img.shields.io/nuget/v/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.svg)](https://www.nuget.org/packages/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection)
   - [![ReactiveUI.Avalonia.Ninject](https://img.shields.io/nuget/v/ReactiveUI.Avalonia.Ninject.svg)](https://www.nuget.org/packages/ReactiveUI.Avalonia.Ninject)
 
-All libraries target multiple frameworks including .NET Standard 2.0 and modern .NET (.NET 8/9/10) for broad compatibility.
+All libraries target .NET 8, 9, 10, and 11. The core and DI packages also have `.Reactive` variants for applications using System.Reactive; new applications can use the lean packages backed by ReactiveUI.Primitives.
+
+## Runnable showcase
+
+The [example application](src/examples/ReactiveUI.Avalonia.Example/README.md) demonstrates navigation, reactive bindings, commands, activation, interactions, reusable metric cards, and live local process measurements using the lean packages.
+
+From `src`, run:
+
+```powershell
+dotnet run --project examples/ReactiveUI.Avalonia.Example/ReactiveUI.Avalonia.Example.csproj -c Release
+```
+
+The example includes headless TUnit tests so its behavior can be checked alongside the package tests.
 
 ---
 ## Recommended setup (ReactiveUIBuilder)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -33,8 +33,6 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <AvaloniaTargetFrameworks>net8.0;net9.0;net10.0;net11.0</AvaloniaTargetFrameworks>
     <IsAotCompatible Condition="'$(IsTestProject)' != 'true'">true</IsAotCompatible>
-    <EnableAotAnalyzer Condition="'$(IsTestProject)' != 'true'">true</EnableAotAnalyzer>
-    <EnableTrimAnalyzer Condition="'$(IsTestProject)' != 'true'">true</EnableTrimAnalyzer>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -5,6 +5,9 @@
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <AndroidUseIntermediateDesignerFile>False</AndroidUseIntermediateDesignerFile>
     <EnableVSTestReferences>false</EnableVSTestReferences>
+    <!-- Evaluate deployment capabilities after each project declares its application/package mode. -->
+    <EnableAotAnalyzer Condition="'$(IsAotCompatible)' == 'true' or '$(PublishAot)' == 'true'">true</EnableAotAnalyzer>
+    <EnableTrimAnalyzer Condition="'$(IsAotCompatible)' == 'true' or '$(IsTrimmable)' == 'true' or '$(PublishTrimmed)' == 'true'">true</EnableTrimAnalyzer>
   </PropertyGroup>
 
   <!-- Keep ReactiveUI.Primitives bridge generation disabled when SDK analyzer resolution ignores ExcludeAssets. -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,7 +6,8 @@
     <SplatVersion>21.0.0</SplatVersion>
     <!-- StyleSharp.Analyzers, PerformanceSharp.Analyzers and SecuritySharp.Analyzers ship from the
          same release pipeline and always share a version. -->
-    <RoslynCommonAnalyzersVersion>3.41.14</RoslynCommonAnalyzersVersion>
+    <RoslynCommonAnalyzersVersion>3.46.1</RoslynCommonAnalyzersVersion>
+    <ReactiveUIPrimitivesVersion>7.4.0</ReactiveUIPrimitivesVersion>
   </PropertyGroup>
 
   <ItemGroup Label="Core packages">
@@ -16,13 +17,13 @@
     <PackageVersion Include="Avalonia.Headless" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400" />
-    <PackageVersion Include="MinVer" Version="7.0.0" />
-    <PackageVersion Include="ReactiveUI" Version="24.1.0" />
-    <PackageVersion Include="ReactiveUI.Primitives" Version="7.3.0" />
-    <PackageVersion Include="ReactiveUI.Primitives.Reactive" Version="7.3.0" />
-    <PackageVersion Include="ReactiveUI.Primitives.Avalonia" Version="7.3.0" />
-    <PackageVersion Include="ReactiveUI.Primitives.Avalonia.Reactive" Version="7.3.0" />
-    <PackageVersion Include="ReactiveUI.Reactive" Version="24.1.0" />
+    <PackageVersion Include="MinVer" Version="8.0.0" />
+    <PackageVersion Include="ReactiveUI" Version="24.2.0" />
+    <PackageVersion Include="ReactiveUI.Primitives" Version="$(ReactiveUIPrimitivesVersion)" />
+    <PackageVersion Include="ReactiveUI.Primitives.Reactive" Version="$(ReactiveUIPrimitivesVersion)" />
+    <PackageVersion Include="ReactiveUI.Primitives.Avalonia" Version="$(ReactiveUIPrimitivesVersion)" />
+    <PackageVersion Include="ReactiveUI.Primitives.Avalonia.Reactive" Version="$(ReactiveUIPrimitivesVersion)" />
+    <PackageVersion Include="ReactiveUI.Reactive" Version="24.2.0" />
     <PackageVersion Include="Splat" Version="$(SplatVersion)" />
     <PackageVersion Include="Splat.Autofac" Version="$(SplatVersion)" />
     <PackageVersion Include="Splat.Drawing" Version="$(SplatVersion)" />
@@ -32,7 +33,7 @@
     <PackageVersion Include="StyleSharp.Analyzers" Version="$(RoslynCommonAnalyzersVersion)" />
     <PackageVersion Include="PerformanceSharp.Analyzers" Version="$(RoslynCommonAnalyzersVersion)" />
     <PackageVersion Include="SecuritySharp.Analyzers" Version="$(RoslynCommonAnalyzersVersion)" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="5.0.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="10.0.11" />
     <PackageVersion Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageVersion Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
@@ -41,7 +42,7 @@
   <ItemGroup Label="Test packages">
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0" />
-    <PackageVersion Include="TUnit" Version="1.66.0" />
+    <PackageVersion Include="TUnit" Version="1.66.27" />
     <PackageVersion Include="Verify.TUnit" Version="32.0.0" />
   </ItemGroup>
 </Project>

--- a/src/ReactiveUI.Avalonia.Reactive/ReactiveUI.Avalonia.Reactive.csproj
+++ b/src/ReactiveUI.Avalonia.Reactive/ReactiveUI.Avalonia.Reactive.csproj
@@ -49,7 +49,7 @@
     <Using Include="ReactiveUI.Reactive.Builder.ReactiveUIBuilder" Alias="ReactiveUIBuilder" />
     <Using Include="ReactiveUI.Reactive.Builder.IReactiveUIBuilder" Alias="IReactiveUIBuilder" />
     <Using Include="ReactiveUI.Reactive.Builder.RxAppBuilder" Alias="RxAppBuilder" />
-    <Using Include="ReactiveUI.Primitives.Disposables.MultipleDisposable" Alias="ActivationDisposables" />
+    <Using Include="ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable" Alias="ActivationDisposables" />
     <Using Include="ReactiveUI.Reactive.RoutingState" Alias="RoutingState" />
     <Using Include="ReactiveUI.Reactive.RxSchedulers" Alias="RxSchedulers" />
     <Using Include="ReactiveUI.Reactive.RxSuspension" Alias="RxSuspension" />

--- a/src/ReactiveUI.Avalonia.slnx
+++ b/src/ReactiveUI.Avalonia.slnx
@@ -22,10 +22,14 @@
     <File Path="Directory.Packages.props" />
   </Folder>
   <Folder Name="/Tests/">
+    <Project Path="examples/ReactiveUI.Avalonia.Example.Tests/ReactiveUI.Avalonia.Example.Tests.csproj" />
     <Project Path="tests/ReactiveUI.Avalonia.DryIoc1.Tests/ReactiveUI.Avalonia.DryIoc.Tests.csproj" />
     <Project Path="tests/ReactiveUI.Avalonia.Microsoft1.Tests/ReactiveUI.Avalonia.Microsoft.Tests.csproj" />
     <Project Path="tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveUI.Avalonia.Reactive.Tests.csproj" />
     <Project Path="tests/ReactiveUI.Avalonia.Tests/ReactiveUI.Avalonia.Tests.csproj" />
+  </Folder>
+  <Folder Name="/Examples/">
+    <Project Path="examples/ReactiveUI.Avalonia.Example/ReactiveUI.Avalonia.Example.csproj" />
   </Folder>
   <Project Path="ReactiveUI.Avalonia.Autofac/ReactiveUI.Avalonia.Autofac.csproj" />
   <Project Path="ReactiveUI.Avalonia.DryIoc/ReactiveUI.Avalonia.DryIoc.csproj" />

--- a/src/ReactiveUI.Avalonia/AutoSuspendHelper.cs
+++ b/src/ReactiveUI.Avalonia/AutoSuspendHelper.cs
@@ -24,6 +24,9 @@ public sealed class AutoSuspendHelper : IEnableLogger, IDisposable
     /// <summary>Signals when process state should be invalidated after an unhandled exception.</summary>
     private readonly Signal<Unit> _shouldInvalidateState = new();
 
+    /// <summary>The controlled lifetime whose exit event is observed.</summary>
+    private readonly IControlledApplicationLifetime? _controlledLifetime;
+
     /// <summary>Initializes a new instance of the <see cref="AutoSuspendHelper"/> class.</summary>
     /// <remarks>If the application is running in design mode, state persistence is disabled. For supported
     /// lifetimes, application exit events are wired to enable state persistence. This constructor should be called
@@ -45,7 +48,8 @@ public sealed class AutoSuspendHelper : IEnableLogger, IDisposable
         else if (lifetime is IControlledApplicationLifetime controlled)
         {
             this.Log().Debug("Using IControlledApplicationLifetime events to handle app exit.");
-            controlled.Exit += (sender, args) => OnControlledApplicationLifetimeExit();
+            _controlledLifetime = controlled;
+            controlled.Exit += OnControlledApplicationLifetimeExit;
             RxSuspension.SuspensionHost.ShouldPersistState = _shouldPersistState;
         }
         else if (lifetime is not null)
@@ -77,6 +81,11 @@ public sealed class AutoSuspendHelper : IEnableLogger, IDisposable
     /// managed resources are properly released. After calling Dispose, the instance should not be used.</remarks>
     public void Dispose()
     {
+        if (_controlledLifetime is not null)
+        {
+            _controlledLifetime.Exit -= OnControlledApplicationLifetimeExit;
+        }
+
         AppDomain.CurrentDomain.UnhandledException -= OnUnhandledException;
         _shouldPersistState.Dispose();
         _isLaunchingNew.Dispose();
@@ -93,10 +102,17 @@ public sealed class AutoSuspendHelper : IEnableLogger, IDisposable
     /// <remarks>This method blocks until all registered state persistence actions have finished executing. It
     /// should be called during application shutdown to guarantee that state is saved reliably. Calling this method from
     /// a non-shutdown context may result in the application waiting indefinitely.</remarks>
-    private void OnControlledApplicationLifetimeExit()
+    /// <param name="sender">The lifetime raising the exit event.</param>
+    /// <param name="args">The application exit arguments.</param>
+    private void OnControlledApplicationLifetimeExit(object? sender, ControlledApplicationLifetimeExitEventArgs args)
     {
         this.Log().Debug("Received IControlledApplicationLifetime exit event.");
-        var manual = new ManualResetEvent(false);
+        if (!_shouldPersistState.HasObservers)
+        {
+            return;
+        }
+
+        using var manual = new ManualResetEvent(false);
         _shouldPersistState.OnNext(Disposable.Create(manual, static state => _ = state.Set()));
 
         _ = manual.WaitOne();

--- a/src/ReactiveUI.Avalonia/AvaloniaCreatesCommandBinding.cs
+++ b/src/ReactiveUI.Avalonia/AvaloniaCreatesCommandBinding.cs
@@ -61,11 +61,11 @@ internal class AvaloniaCreatesCommandBinding : ICreatesCommandBinding
     /// command parameter. This method is typically used to enable dynamic command parameter updates in UI elements such
     /// as buttons or menu items.</remarks>
     /// <typeparam name="T">The type of the target object. Must be a class that is both an InputElement and implements ICommandSource.</typeparam>
-    /// <param name="command">The command to bind, or null when no binding should be created.</param>
+    /// <param name="command">The command to bind, or null to clear the command on a valid command source.</param>
     /// <param name="target">The command target, or null when no binding should be created.</param>
     /// <param name="commandParameter">An observable sequence that provides values for the command parameter. The command parameter will be updated
     /// whenever the observable emits a new value.</param>
-    /// <returns>An IDisposable that, when disposed, unbinds the command and command parameter from the target object.</returns>
+    /// <returns>A disposable binding, an empty disposable when clearing a valid command source, or null when no target can be bound.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the target object does not implement both InputElement and ICommandSource.</exception>
     [RequiresUnreferencedCode("String/reflection-based event binding may require members removed by trimming.")]
     public IDisposable? BindCommandToObject<
@@ -75,9 +75,20 @@ internal class AvaloniaCreatesCommandBinding : ICreatesCommandBinding
         IObservable<object?> commandParameter)
         where T : class
     {
-        if (command is null || target is null)
+        if (target is null)
         {
             return null;
+        }
+
+        if (command is null)
+        {
+            if (target is not (InputElement inputElement and ICommandSource))
+            {
+                return null;
+            }
+
+            inputElement.SetCurrentValue(Button.CommandProperty, null);
+            return Disposable.Empty;
         }
 
         if (target is not (InputElement element and ICommandSource))
@@ -88,9 +99,14 @@ internal class AvaloniaCreatesCommandBinding : ICreatesCommandBinding
         // Button.CommandProperty is reused for all button-like controls and menu item
         element.SetCurrentValue(Button.CommandProperty, command);
         var paramDisposable = element.Bind(Button.CommandParameterProperty, commandParameter);
-        return Disposable.Create((AvaloniaObject: element, ParamDisposable: paramDisposable), static t =>
+        return Disposable.Create((AvaloniaObject: element, Command: command, ParamDisposable: paramDisposable), static t =>
         {
             t.ParamDisposable.Dispose();
+            if (!ReferenceEquals(t.AvaloniaObject.GetValue(Button.CommandProperty), t.Command))
+            {
+                return;
+            }
+
             t.AvaloniaObject.ClearValue(Button.CommandProperty);
         });
     }

--- a/src/ReactiveUI.Avalonia/RoutedViewHost.cs
+++ b/src/ReactiveUI.Avalonia/RoutedViewHost.cs
@@ -150,6 +150,19 @@ public class RoutedViewHost : TransitioningContentControl, IActivatableView, IEn
         DisposeNavigationDisposables();
     }
 
+    /// <summary>Gets the current routed view model from the navigation stack.</summary>
+    /// <param name="router">The router to inspect.</param>
+    /// <returns>The current routed view model, or null when the stack is empty.</returns>
+    private static object? GetCurrentViewModel(RoutingState router) =>
+        router.NavigationStack.Count == 0 ? null : router.NavigationStack[router.NavigationStack.Count - 1];
+
+    /// <summary>Creates a stream that begins with the router's current view model and then follows future navigation.</summary>
+    /// <param name="router">The router to observe.</param>
+    /// <returns>The current and future routed view models.</returns>
+    private static IObservable<object?> CreateRouterViewModelObservable(RoutingState router) =>
+        Observable.Return(GetCurrentViewModel(router))
+            .Merge(router.CurrentViewModel.Select(static viewModel => (object?)viewModel));
+
     /// <summary>Creates the active navigation subscriptions for an attached host.</summary>
     /// <param name="e">The visual tree attachment event arguments.</param>
     /// <returns>The created navigation subscriptions.</returns>
@@ -158,16 +171,12 @@ public class RoutedViewHost : TransitioningContentControl, IActivatableView, IEn
         base.OnAttachedToVisualTree(e);
 
         var disposables = new CompositeDisposable();
-        IObservable<object?> routerChanges = this.GetObservable(RouterProperty);
-        var routerRemoved = routerChanges
-            .Where(static router => router is null);
-
+        IObservable<RoutingState?> routerChanges = this.GetObservable(RouterProperty);
         var viewContract = this.GetObservable(ViewContractProperty);
-
-        var navigation = this.GetObservable(RouterProperty)
-            .Where(static router => router is not null)
-            .SelectMany(static router => router!.CurrentViewModel)
-            .Merge(routerRemoved)
+        var viewModels = routerChanges
+            .Select(static router => router is null ? Observable.Return<object?>(null) : CreateRouterViewModelObservable(router))
+            .Switch();
+        var navigation = viewModels
             .CombineLatest(viewContract, static (viewModel, contract) => new NavigationTarget(viewModel, contract));
 
         var subscription = PrimitivesLinqExtensions.SubscribeSafe(

--- a/src/examples/ReactiveUI.Avalonia.Example.Tests/CallerTestExecutor.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example.Tests/CallerTestExecutor.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using TUnit.Core.Interfaces;
+
+namespace ReactiveUI.Avalonia.Example.Tests;
+
+/// <summary>Runs executor regression tests outside the headless dispatch queue to avoid nested dispatch.</summary>
+public sealed class CallerTestExecutor : ITestExecutor
+{
+    /// <inheritdoc/>
+    public ValueTask ExecuteTest(TestContext context, Func<ValueTask> action) => action();
+}

--- a/src/examples/ReactiveUI.Avalonia.Example.Tests/ExampleAvaloniaTestExecutor.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example.Tests/ExampleAvaloniaTestExecutor.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using ReactiveUI.Avalonia.Example.Tests;
+using TUnit.Core.Executors;
+using TUnit.Core.Interfaces;
+
+[assembly: NotInParallel]
+[assembly: TestExecutor<ExampleAvaloniaTestExecutor>]
+
+namespace ReactiveUI.Avalonia.Example.Tests;
+
+/// <summary>Runs every example test on the application's headless UI thread.</summary>
+public sealed class ExampleAvaloniaTestExecutor : ITestExecutor
+{
+    /// <inheritdoc/>
+    public async ValueTask ExecuteTest(TestContext context, Func<ValueTask> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        _ = await ExampleAvaloniaTestSession.Instance.Dispatch(
+            async () =>
+            {
+                await action();
+                return true;
+            },
+            CancellationToken.None);
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example.Tests/ExampleAvaloniaTestSession.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example.Tests/ExampleAvaloniaTestSession.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Avalonia;
+using Avalonia.Headless;
+
+namespace ReactiveUI.Avalonia.Example.Tests;
+
+/// <summary>Provides the shared headless Avalonia test session.</summary>
+public static class ExampleAvaloniaTestSession
+{
+    /// <summary>The lazily-created headless session.</summary>
+    private static readonly Lazy<HeadlessUnitTestSession> Session =
+        new(static () => HeadlessUnitTestSession.StartNew(typeof(ExampleAvaloniaTestSession), AvaloniaTestIsolationLevel.PerAssembly), LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>Gets the shared headless session.</summary>
+    internal static HeadlessUnitTestSession Instance => Session.Value;
+
+    /// <summary>Uses the production application setup with a headless rendering backend.</summary>
+    /// <returns>The configured application builder.</returns>
+    public static AppBuilder BuildAvaloniaApp() => Program.BuildAvaloniaApp().UseHeadless(new());
+}

--- a/src/examples/ReactiveUI.Avalonia.Example.Tests/ExampleTestExecutorTests.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example.Tests/ExampleTestExecutorTests.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using TUnit.Core.Executors;
+
+namespace ReactiveUI.Avalonia.Example.Tests;
+
+/// <summary>Guards against reporting success before a dispatched asynchronous assertion completes.</summary>
+[TestExecutor<CallerTestExecutor>]
+public sealed class ExampleTestExecutorTests
+{
+    /// <summary>Verifies asynchronous failures propagate out of the headless executor.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Headless_Executor_Propagates_Failure_After_Async_Yield()
+    {
+        var executor = new ExampleAvaloniaTestExecutor();
+        await Assert.That(() => executor.ExecuteTest(TestContext.Current!, static async () =>
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("Expected asynchronous test failure.");
+        }).AsTask()).ThrowsExactly<InvalidOperationException>();
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example.Tests/LocalMachineMetricsServiceTests.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example.Tests/LocalMachineMetricsServiceTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using ReactiveUI.Avalonia.Example.Services;
+using ReactiveUI.Primitives;
+
+namespace ReactiveUI.Avalonia.Example.Tests;
+
+/// <summary>Exercises the real local process sampler and its periodic observable.</summary>
+public sealed class LocalMachineMetricsServiceTests
+{
+    /// <summary>The test sample interval.</summary>
+    private static readonly TimeSpan SampleInterval = TimeSpan.FromMilliseconds(20);
+
+    /// <summary>The maximum wait for a periodic sample.</summary>
+    private static readonly TimeSpan SampleTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Verifies the live service produces more than its initial snapshot.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Watch_Produces_Periodic_Process_Measurements()
+    {
+        const int requiredSamples = 2;
+        const double maximumPercentage = 100;
+        var service = new LocalMachineMetricsService();
+        var snapshot = await service.Watch(SampleInterval)
+            .Take(requiredSamples).ToTask().WaitAsync(SampleTimeout);
+        await Assert.That(snapshot.WorkingSetMegabytes).IsGreaterThan(0);
+        await Assert.That(snapshot.ManagedMegabytes).IsGreaterThan(0);
+        await Assert.That(snapshot.ThreadCount).IsGreaterThan(0);
+        await Assert.That(snapshot.ProcessorPercent).IsGreaterThanOrEqualTo(0);
+        await Assert.That(snapshot.ProcessorPercent).IsLessThanOrEqualTo(maximumPercentage);
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example.Tests/ReactiveUI.Avalonia.Example.Tests.csproj
+++ b/src/examples/ReactiveUI.Avalonia.Example.Tests/ReactiveUI.Avalonia.Example.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <OutputType>Exe</OutputType>
+    <IsTestProject>true</IsTestProject>
+    <AssemblyName>ReactiveUI.Avalonia.Example.Tests</AssemblyName>
+    <RootNamespace>ReactiveUI.Avalonia.Example.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Headless" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReactiveUI.Avalonia.Example\ReactiveUI.Avalonia.Example.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/examples/ReactiveUI.Avalonia.Example.Tests/ShowcaseHeadlessTests.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example.Tests/ShowcaseHeadlessTests.cs
@@ -1,0 +1,248 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using ReactiveUI;
+using ReactiveUI.Avalonia.Example.Models;
+using ReactiveUI.Avalonia.Example.Services;
+using ReactiveUI.Avalonia.Example.ViewModels;
+using ReactiveUI.Avalonia.Example.Views;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Concurrency;
+using ReactiveUI.Primitives.Disposables;
+using ReactiveUI.Primitives.Signals;
+using Splat;
+
+namespace ReactiveUI.Avalonia.Example.Tests;
+
+/// <summary>Tests the production application setup and rendered view lifetimes.</summary>
+public sealed class ShowcaseHeadlessTests
+{
+    /// <summary>The width of a test window.</summary>
+    private const int WindowWidth = 1000;
+
+    /// <summary>The height of a test window.</summary>
+    private const int WindowHeight = 700;
+
+    /// <summary>The maximum wait for a dispatched measurement.</summary>
+    private static readonly TimeSpan DispatchTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Verifies the explicit light palette remains legible when Windows uses a dark theme.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Showcase_Uses_Explicit_Light_Theme() =>
+        await Assert.That(Application.Current!.RequestedThemeVariant).IsEqualTo(ThemeVariant.Light);
+
+    /// <summary>Verifies button ICommand execution routes asynchronous errors to the view interaction.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Failure_Button_Executes_And_Reports_Error()
+    {
+        await Assert.That(AvaloniaScheduler.Instance.Dispatcher).IsSameReferenceAs(Dispatcher.UIThread);
+        using var service = new CountingMetricsService();
+        using var shell = MainViewModel.Create(service);
+        var window = new MainWindow { ViewModel = shell };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            shell.Navigate(shell.Commands);
+            Dispatcher.UIThread.RunJobs();
+            var view = (CommandLabView)window.FindControl<RoutedViewHost>("RouterHost")!.Content!;
+            var button = view.FindControl<Button>("FailWorkButton")!;
+            await Assert.That(button.Command).IsSameReferenceAs(shell.Commands.FailWork);
+            await Assert.That(button.IsEffectivelyEnabled).IsTrue();
+            await Assert.That(button.Command!.CanExecute(null)).IsTrue();
+            var acknowledged = shell.Commands.WhenAnyValue(static model => model.AcknowledgedErrors)
+                .Where(static count => count > 0).Take(1).ToTask();
+            var center = button.TranslatePoint(new Rect(button.Bounds.Size).Center, window)!.Value;
+            window.MouseDown(center, MouseButton.Left);
+            window.MouseUp(center, MouseButton.Left);
+            _ = await acknowledged.WaitAsync(DispatchTimeout);
+            await Assert.That(shell.Commands.LastError).IsEqualTo("The sample command failed by design.");
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies real view bindings, command availability, and interaction disposal across activation.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Command_View_Binds_Input_And_Handles_Interactions_Only_While_Active()
+    {
+        const string initialInput = "Review measurements";
+        const int expectedAcknowledgements = 2;
+        using var service = new CountingMetricsService();
+        using var shell = MainViewModel.Create(service);
+        var view = new CommandLabView { ViewModel = shell.Commands };
+        var window = new Window { Content = view, Width = WindowWidth, Height = WindowHeight };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            var input = view.FindControl<TextBox>("WorkItemTextBox")!;
+            var button = view.FindControl<Button>("RunWorkButton")!;
+            await Assert.That(button.IsEffectivelyEnabled).IsFalse();
+            input.Text = initialInput;
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(shell.Commands.WorkItemText).IsEqualTo(initialInput);
+            await Assert.That(button.IsEffectivelyEnabled).IsTrue();
+            await Assert.That(button.Command).IsSameReferenceAs(shell.Commands.RunWork);
+            _ = await shell.Commands.ReportError.Handle("Expected test interaction").ToTask();
+            await Assert.That(shell.Commands.AcknowledgedErrors).IsEqualTo(1);
+            window.Content = null;
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(button.Command).IsNull();
+            shell.Commands.WorkItemText = "Changed while inactive";
+            await Assert.That(input.Text).IsEqualTo(initialInput);
+            window.Content = view;
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(input.Text).IsEqualTo("Changed while inactive");
+            _ = await shell.Commands.ReportError.Handle("Reactivated interaction").ToTask();
+            await Assert.That(shell.Commands.AcknowledgedErrors).IsEqualTo(expectedAcknowledgements);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies activation starts, stops, and resumes the live subscription.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Metrics_View_Activation_Stops_And_Resumes_Live_Subscription()
+    {
+        using var service = new CountingMetricsService();
+        using var shell = MainViewModel.Create(service);
+        var view = new MetricsView { ViewModel = shell.Metrics };
+        var window = new Window { Content = view, Width = WindowWidth, Height = WindowHeight };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(service.ActiveSubscriptions).IsEqualTo(1);
+
+            window.Content = null;
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(service.ActiveSubscriptions).IsEqualTo(0);
+            var sampleCount = shell.Metrics.SampleCount;
+            service.Publish();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(shell.Metrics.SampleCount).IsEqualTo(sampleCount);
+
+            window.Content = view;
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(service.ActiveSubscriptions).IsEqualTo(1);
+        }
+        finally
+        {
+            window.Close();
+        }
+
+        await Assert.That(service.ActiveSubscriptions).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies worker-thread measurements are dispatched before changing UI-bound state.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Metrics_View_Marshals_Background_Samples_To_UI_Thread()
+    {
+        using var service = new CountingMetricsService();
+        using var shell = MainViewModel.Create(service);
+        var window = new Window { Content = new MetricsView { ViewModel = shell.Metrics }, Width = WindowWidth, Height = WindowHeight };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            var updated = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var changes = shell.Metrics.Changed
+                .Where(static change => change.PropertyName == nameof(MetricsViewModel.SampleCount))
+                .SubscribeSafe(_ => updated.TrySetResult(Dispatcher.UIThread.CheckAccess()), error => updated.TrySetException(error));
+            await Task.Run(service.Publish);
+            await Assert.That(await updated.Task.WaitAsync(DispatchTimeout)).IsTrue();
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies startup resolves the initial route and all contracted metric cards through real DI setup.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Production_Startup_Resolves_Initial_Route_And_Contracted_Cards()
+    {
+        using var service = new CountingMetricsService();
+        using var shell = MainViewModel.Create(service);
+        var window = new MainWindow { ViewModel = shell };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(AppLocator.Current.GetService<IViewFor<MetricCardViewModel>>("performance")).IsTypeOf<PerformanceMetricCardView>();
+            await Assert.That(AppLocator.Current.GetService<IViewFor<MetricCardViewModel>>("memory")).IsTypeOf<MemoryMetricCardView>();
+            var host = window.FindControl<RoutedViewHost>("RouterHost")!;
+            await Assert.That(host.Content).IsTypeOf<OverviewView>();
+            var overview = (OverviewView)host.Content!;
+            var items = overview.FindControl<ItemsControl>("FeatureItems")!;
+            await Assert.That(items.ItemTemplate).IsNotNull();
+            var renderedFeatures = 0;
+            foreach (var descendant in items.GetVisualDescendants())
+            {
+                if (descendant is FeatureView)
+                {
+                    renderedFeatures++;
+                }
+            }
+
+            await Assert.That(renderedFeatures).IsEqualTo(overview.ViewModel!.Features.Count);
+            shell.Navigate(shell.Metrics);
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(host.Content).IsTypeOf<MetricsView>();
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>A controllable measurement source that records subscription ownership.</summary>
+    private sealed class CountingMetricsService : ILocalMachineMetricsService, IDisposable
+    {
+        /// <summary>The source of subsequent measurements.</summary>
+        private readonly Signal<MachineSnapshot> _samples = new();
+
+        /// <summary>Gets the active subscription count.</summary>
+        internal int ActiveSubscriptions { get; private set; }
+
+        /// <inheritdoc/>
+        public MachineSnapshot ReadSnapshot() => MachineSnapshot.Empty;
+
+        /// <inheritdoc/>
+        public IObservable<MachineSnapshot> Watch(TimeSpan interval) => Signal.Create<MachineSnapshot>(observer =>
+        {
+            ActiveSubscriptions++;
+            observer.OnNext(ReadSnapshot());
+            var subscription = _samples.Subscribe(observer);
+            return Scope.Create((Subscription: subscription, Service: this), static state =>
+            {
+                state.Subscription.Dispose();
+                state.Service.ActiveSubscriptions--;
+            });
+        });
+
+        /// <inheritdoc/>
+        public void Dispose() => _samples.Dispose();
+
+        /// <summary>Pushes another measurement on the calling thread.</summary>
+        internal void Publish() => _samples.OnNext(ReadSnapshot());
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example.Tests/ShowcaseSessionTests.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example.Tests/ShowcaseSessionTests.cs
@@ -1,0 +1,89 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
+using Avalonia.Controls.ApplicationLifetimes;
+using ReactiveUI.Avalonia.Example.Services;
+using ReactiveUI.Avalonia.Example.ViewModels;
+using ReactiveUI.Primitives.Disposables;
+
+namespace ReactiveUI.Avalonia.Example.Tests;
+
+/// <summary>Tests suspension persistence and deferral release against isolated temporary session files.</summary>
+public sealed class ShowcaseSessionTests
+{
+    /// <summary>Verifies a persistence request saves settings and the next launch restores them.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Persistence_Saves_And_Next_Launch_Restores_Settings()
+    {
+        const string savedInput = "Inspect working set";
+        const double savedThreshold = 63;
+        var directory = Path.Combine(Path.GetTempPath(), $"AvaloniaShowcase-{Guid.NewGuid():N}");
+        var path = Path.Combine(directory, "session.json");
+        try
+        {
+            using (var shell = MainViewModel.Create(new LocalMachineMetricsService()))
+            {
+                var lifetime = new ClassicDesktopStyleApplicationLifetime();
+                using var session = new ShowcaseSession(lifetime, shell, path);
+                session.Start();
+                shell.Commands.WorkItemText = savedInput;
+                shell.Metrics.CpuWarningThreshold = savedThreshold;
+                var released = new StrongBox<bool>();
+                session.Persist(Scope.Create(released, static state => state.Value = true));
+                await Assert.That(released.Value).IsTrue();
+                await Assert.That(File.Exists(path)).IsTrue();
+                await Assert.That(shell.SessionStatus).IsEqualTo("Session saved.");
+            }
+
+            using (var shell = MainViewModel.Create(new LocalMachineMetricsService()))
+            {
+                using var session = new ShowcaseSession(new ClassicDesktopStyleApplicationLifetime(), shell, path);
+                session.Start();
+                await Assert.That(shell.Commands.WorkItemText).IsEqualTo(savedInput);
+                await Assert.That(shell.Metrics.CpuWarningThreshold).IsEqualTo(savedThreshold);
+            }
+
+            await File.WriteAllTextAsync(path, "Invalid JSON");
+            using var recovered = MainViewModel.Create(new LocalMachineMetricsService());
+            using var recovery = new ShowcaseSession(new ClassicDesktopStyleApplicationLifetime(), recovered, path);
+            recovery.Start();
+            await Assert.That(recovered.SessionStatus).StartsWith("Session storage:");
+            await Assert.That(recovered.Commands.WorkItemText).IsEqualTo(string.Empty);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    /// <summary>Verifies a failed save still releases the platform shutdown deferral.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Storage_Failure_Still_Releases_Shutdown_Deferral()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"AvaloniaShowcase-{Guid.NewGuid():N}");
+        _ = Directory.CreateDirectory(directory);
+        var invalidFile = Path.Combine(directory, "directory-instead-of-file");
+        _ = Directory.CreateDirectory(invalidFile);
+        try
+        {
+            using var shell = MainViewModel.Create(new LocalMachineMetricsService());
+            var lifetime = new ClassicDesktopStyleApplicationLifetime();
+            using var session = new ShowcaseSession(lifetime, shell, invalidFile);
+            session.Start();
+            var released = new StrongBox<bool>();
+            session.Persist(Scope.Create(released, static state => state.Value = true));
+            await Assert.That(released.Value).IsTrue();
+            await Assert.That(shell.SessionStatus).StartsWith("Session storage:");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example.Tests/ShowcaseViewModelTests.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example.Tests/ShowcaseViewModelTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Windows.Input;
+using Avalonia.Threading;
+using ReactiveUI.Avalonia.Example.Models;
+using ReactiveUI.Avalonia.Example.Services;
+using ReactiveUI.Avalonia.Example.ViewModels;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Signals;
+using Unit = ReactiveUI.Primitives.RxVoid;
+
+namespace ReactiveUI.Avalonia.Example.Tests;
+
+/// <summary>Tests the showcase's commands, routing, and computed state.</summary>
+public sealed class ShowcaseViewModelTests
+{
+    /// <summary>The sample CPU utilization.</summary>
+    private const double ProcessorPercent = 12.5;
+
+    /// <summary>The warning threshold below the sample utilization.</summary>
+    private const double WarningThreshold = 10;
+
+    /// <summary>Verifies navigation, back availability, and reset through the real routing commands.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Shell_Navigates_Back_And_Resets_With_Router_Commands()
+    {
+        using var viewModel = MainViewModel.Create(new FixedMetricsService());
+        await Assert.That(viewModel.Router.NavigationStack).Count().IsEqualTo(1);
+        await Assert.That(viewModel.Router.NavigationStack[0]).IsTypeOf<OverviewViewModel>();
+        await Assert.That(((ICommand)viewModel.GoBack).CanExecute(null)).IsFalse();
+
+        viewModel.Navigate(viewModel.Metrics);
+        await Assert.That(((ICommand)viewModel.GoBack).CanExecute(null)).IsTrue();
+        await viewModel.GoBack.Execute(Unit.Default).ToTask();
+        await Assert.That(viewModel.Router.NavigationStack[0]).IsTypeOf<OverviewViewModel>();
+
+        viewModel.Navigate(viewModel.Commands);
+        viewModel.ResetNavigation();
+        await Assert.That(viewModel.Router.NavigationStack).Count().IsEqualTo(1);
+        await Assert.That(viewModel.Router.NavigationStack[0]).IsTypeOf<OverviewViewModel>();
+        await Assert.That(((ICommand)viewModel.GoBack).CanExecute(null)).IsFalse();
+    }
+
+    /// <summary>Verifies can-execute, input capture during async work, and error interaction acknowledgement.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Command_Lab_Uses_CanExecute_Async_And_Interaction_Acknowledgement()
+    {
+        using var shell = MainViewModel.Create(new FixedMetricsService());
+        var viewModel = shell.Commands;
+        await Assert.That(((ICommand)viewModel.RunWork).CanExecute(null)).IsFalse();
+
+        viewModel.WorkItemText = "sample";
+        await Assert.That(((ICommand)viewModel.RunWork).CanExecute(null)).IsTrue();
+        var operation = viewModel.RunWork.Execute(Unit.Default).ToTask();
+        viewModel.WorkItemText = "changed during execution";
+        var result = await operation;
+        Dispatcher.UIThread.RunJobs();
+        await Assert.That(result).Contains("'sample'");
+        await Assert.That(viewModel.LastResult).IsEqualTo(result);
+
+        using var handler = viewModel.ReportError.RegisterHandler(context =>
+        {
+            viewModel.AcknowledgeError(context.Input);
+            context.SetOutput(Unit.Default);
+        });
+        await Assert.That(() => viewModel.FailWork.Execute(Unit.Default).ToTask()).ThrowsExactly<InvalidOperationException>();
+        Dispatcher.UIThread.RunJobs();
+        await Assert.That(viewModel.LastError).IsEqualTo("The sample command failed by design.");
+        await Assert.That(viewModel.AcknowledgedErrors).IsEqualTo(1);
+        await Assert.That(viewModel.InteractionStatus).Contains("acknowledged");
+    }
+
+    /// <summary>Verifies computed warning state follows both incoming measurements and user input.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Metrics_Page_Applies_Samples_And_Computes_Load_Label()
+    {
+        using var shell = MainViewModel.Create(new FixedMetricsService());
+        var viewModel = shell.Metrics;
+        viewModel.CpuWarningThreshold = WarningThreshold;
+        viewModel.ApplySnapshot(FixedMetricsService.Snapshot);
+
+        await Assert.That(viewModel.ProcessorCard.Value).IsEqualTo("12.5%");
+        await Assert.That(viewModel.MemoryCard.Value).IsEqualTo("128.0 MB");
+        await Assert.That(viewModel.ManagedCard.Value).IsEqualTo("32.0 MB");
+        await Assert.That(viewModel.SampleCount).IsEqualTo(1);
+        await Assert.That(viewModel.LoadLabel).Contains("at or above");
+        viewModel.CpuWarningThreshold = ProcessorPercent + 1;
+        await Assert.That(viewModel.LoadLabel).Contains("below");
+    }
+
+    /// <summary>A deterministic measurement source for view-model tests.</summary>
+    private sealed class FixedMetricsService : ILocalMachineMetricsService
+    {
+        /// <summary>The sample working set in megabytes.</summary>
+        private const double WorkingSet = 128;
+
+        /// <summary>The sample managed heap in megabytes.</summary>
+        private const double ManagedHeap = 32;
+
+        /// <summary>The sample thread count.</summary>
+        private const int ThreadCount = 8;
+
+        /// <summary>Gets the fixed sample.</summary>
+        internal static MachineSnapshot Snapshot => new(DateTimeOffset.UnixEpoch, ProcessorPercent, WorkingSet, ManagedHeap, ThreadCount, "fixed");
+
+        /// <inheritdoc/>
+        public MachineSnapshot ReadSnapshot() => Snapshot;
+
+        /// <inheritdoc/>
+        public IObservable<MachineSnapshot> Watch(TimeSpan interval) => Signal.Return(Snapshot);
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/App.axaml
+++ b/src/examples/ReactiveUI.Avalonia.Example/App.axaml
@@ -1,0 +1,10 @@
+<Application
+    x:Class="ReactiveUI.Avalonia.Example.App"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    RequestedThemeVariant="Light">
+    <Application.Styles>
+        <FluentTheme />
+        <StyleInclude Source="avares://ReactiveUI.Avalonia.Example/Views/ShowcaseStyles.axaml" />
+    </Application.Styles>
+</Application>

--- a/src/examples/ReactiveUI.Avalonia.Example/App.axaml.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/App.axaml.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using ReactiveUI;
+using ReactiveUI.Avalonia.Example.Services;
+using ReactiveUI.Avalonia.Example.ViewModels;
+using ReactiveUI.Avalonia.Example.Views;
+using Splat;
+
+namespace ReactiveUI.Avalonia.Example;
+
+/// <summary>The example Avalonia application.</summary>
+public sealed class App : Application
+{
+    /// <summary>Gets the window factory composed by the desktop entry point.</summary>
+    public Func<IClassicDesktopStyleApplicationLifetime, Window>? MainWindowFactory { get; init; }
+
+    /// <summary>Registers view and service dependencies for the example.</summary>
+    /// <param name="resolver">The resolver to update.</param>
+    [RequiresUnreferencedCode("The registered views demonstrate reflection-based ReactiveUI binding and activation.")]
+    [RequiresDynamicCode("The registered views demonstrate dynamic ReactiveUI bindings.")]
+    public static void RegisterViews(IMutableDependencyResolver resolver)
+    {
+        resolver.RegisterLazySingleton<ILocalMachineMetricsService>(static () => new LocalMachineMetricsService());
+        resolver.Register<IViewFor<OverviewViewModel>>(static () => new OverviewView());
+        resolver.Register<IViewFor<MetricsViewModel>>(static () => new MetricsView());
+        resolver.Register<IViewFor<CommandLabViewModel>>(static () => new CommandLabView());
+        resolver.Register<IViewFor<FeatureViewModel>>(static () => new FeatureView());
+        resolver.Register(static () => new PerformanceMetricCardView(), typeof(IViewFor<MetricCardViewModel>), "performance");
+        resolver.Register(static () => new MemoryMetricCardView(), typeof(IViewFor<MetricCardViewModel>), "memory");
+    }
+
+    /// <inheritdoc/>
+    public override void Initialize() => AvaloniaXamlLoader.Load(this);
+
+    /// <inheritdoc/>
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = MainWindowFactory?.Invoke(desktop)
+                ?? throw new InvalidOperationException("The desktop window factory has not been configured.");
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/Models/MachineSnapshot.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Models/MachineSnapshot.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace ReactiveUI.Avalonia.Example.Models;
+
+/// <summary>Represents one local machine measurement sample.</summary>
+public sealed record MachineSnapshot
+{
+    /// <summary>Initializes a new instance of the <see cref="MachineSnapshot"/> class.</summary>
+    /// <param name="capturedAt">The local time when the sample was captured.</param>
+    /// <param name="processorPercent">The estimated process CPU percentage.</param>
+    /// <param name="workingSetMegabytes">The process working-set size in megabytes.</param>
+    /// <param name="managedMegabytes">The managed heap size in megabytes.</param>
+    /// <param name="threadCount">The process thread count.</param>
+    /// <param name="status">The feed status text.</param>
+    public MachineSnapshot(
+        DateTimeOffset capturedAt,
+        double processorPercent,
+        double workingSetMegabytes,
+        double managedMegabytes,
+        int threadCount,
+        string status)
+    {
+        CapturedAt = capturedAt;
+        ProcessorPercent = processorPercent;
+        WorkingSetMegabytes = workingSetMegabytes;
+        ManagedMegabytes = managedMegabytes;
+        ThreadCount = threadCount;
+        Status = status;
+    }
+
+    /// <summary>Gets an empty sample used before the first live update arrives.</summary>
+    public static MachineSnapshot Empty { get; } = new(DateTimeOffset.UnixEpoch, 0, 0, 0, 0, "Waiting for the first local sample.");
+
+    /// <summary>Gets the local time when the sample was captured.</summary>
+    public DateTimeOffset CapturedAt { get; init; }
+
+    /// <summary>Gets the estimated process CPU percentage.</summary>
+    public double ProcessorPercent { get; init; }
+
+    /// <summary>Gets the process working-set size in megabytes.</summary>
+    public double WorkingSetMegabytes { get; init; }
+
+    /// <summary>Gets the managed heap size in megabytes.</summary>
+    public double ManagedMegabytes { get; init; }
+
+    /// <summary>Gets the process thread count.</summary>
+    public int ThreadCount { get; init; }
+
+    /// <summary>Gets the feed status text.</summary>
+    public string Status { get; init; }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/Models/ShowcaseJsonContext.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Models/ShowcaseJsonContext.cs
@@ -1,0 +1,10 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Text.Json.Serialization;
+
+namespace ReactiveUI.Avalonia.Example.Models;
+
+/// <summary>Provides generated JSON metadata for persisted showcase settings.</summary>
+[JsonSerializable(typeof(ShowcaseState))]
+internal sealed partial class ShowcaseJsonContext : JsonSerializerContext;

--- a/src/examples/ReactiveUI.Avalonia.Example/Models/ShowcaseState.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Models/ShowcaseState.cs
@@ -1,0 +1,9 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace ReactiveUI.Avalonia.Example.Models;
+
+/// <summary>The small, serializable state restored between desktop sessions.</summary>
+/// <param name="WorkItemText">The command input.</param>
+/// <param name="CpuWarningThreshold">The CPU warning threshold.</param>
+public sealed record ShowcaseState(string WorkItemText, double CpuWarningThreshold);

--- a/src/examples/ReactiveUI.Avalonia.Example/Program.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Program.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using ReactiveUI.Avalonia.Example.Services;
+using ReactiveUI.Avalonia.Example.ViewModels;
+using ReactiveUI.Avalonia.Example.Views;
+using ReactiveUI.Avalonia.Splat;
+using Splat;
+
+namespace ReactiveUI.Avalonia.Example;
+
+/// <summary>The executable entry point for the example app.</summary>
+public static class Program
+{
+    /// <summary>Runs the example app.</summary>
+    /// <param name="args">Command-line arguments.</param>
+    [STAThread]
+    public static void Main(string[] args) => _ = BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+
+    /// <summary>Builds the Avalonia app with ReactiveUI and Microsoft dependency resolver integration.</summary>
+    /// <returns>The configured app builder.</returns>
+    [RequiresUnreferencedCode("The desktop showcase uses expression-based ReactiveUI bindings.")]
+    [RequiresDynamicCode("The desktop showcase uses dynamic ReactiveUI bindings.")]
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure(static () => new App { MainWindowFactory = CreateMainWindow })
+            .UsePlatformDetect()
+            .WithInterFont()
+            .LogToTrace()
+            .UseReactiveUIWithMicrosoftDependencyResolver(
+                static _ => App.RegisterViews(AppLocator.CurrentMutable),
+                null,
+                static builder => builder.WithCoreServices());
+
+    /// <summary>Creates the main window after application services have been registered.</summary>
+    /// <param name="lifetime">The desktop lifetime.</param>
+    /// <returns>The initialized desktop window.</returns>
+    [RequiresUnreferencedCode("The window demonstrates expression-based ReactiveUI bindings.")]
+    [RequiresDynamicCode("The window demonstrates dynamic ReactiveUI bindings.")]
+    private static MainWindow CreateMainWindow(IClassicDesktopStyleApplicationLifetime lifetime)
+    {
+        var shell = MainViewModel.Create(AppLocator.Current.GetService<ILocalMachineMetricsService>()
+            ?? throw new InvalidOperationException("The local metrics service has not been registered."));
+        var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ReactiveUI.Avalonia.Example", "session.json");
+        var session = new ShowcaseSession(lifetime, shell, path);
+        lifetime.Exit += (_, _) => session.Dispose();
+        session.Start();
+        return new MainWindow { ViewModel = shell };
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/README.md
+++ b/src/examples/ReactiveUI.Avalonia.Example/README.md
@@ -1,0 +1,40 @@
+# ReactiveUI.Avalonia Example
+
+This example is a small desktop showcase for the lean ReactiveUI.Avalonia package graph. It uses `ReactiveUI`, `ReactiveUI.Primitives`, project-referenced `ReactiveUI.Avalonia`, and the Microsoft dependency resolver integration.
+
+It targets .NET 10 and runs as a normal, untrimmed desktop application. Traditional expression-based ReactiveUI binding and activation use reflection; this example does not claim Native AOT compatibility. Package projects retain their declared trimming/AOT analysis.
+
+Run it from the `src` folder:
+
+```powershell
+dotnet run --project examples/ReactiveUI.Avalonia.Example/ReactiveUI.Avalonia.Example.csproj -c Release
+```
+
+The app demonstrates:
+
+- `RoutedViewHost` navigation with home, metrics, commands, back, and reset flows.
+- `ViewModelViewHost` resolution with explicit view contracts for reusable metric cards.
+- Live local machine measurements from `Process`, `GC`, and `Environment` without network or fake feed data.
+- One-way and two-way bindings, `ReactiveCommand` can-execute, async execution, error reporting, and interactions.
+- Computed state with `ObservableAsPropertyHelper`.
+- `WhenActivated` lifetime wiring in views and view models.
+- Avalonia property subjects through `GetSubject` and `GetBindingSubject` on a color intensity preview.
+- `AutoDataTemplateBindingHook` resolves the overview's feature rows from an `ItemsControl` with no explicit item template.
+- `AutoSuspendHelper` restores the command input and CPU threshold on launch, persists them on exit, and invalidates the saved state after an unhandled exception.
+
+Try these flows:
+
+1. Open **Live metrics**. The CPU, working-set, and managed-heap cards show measurements from this application process. The sample count advances every second while this page is active. Move the threshold slider and watch the computed warning label and property-subject preview.
+2. Open **Command lab**. Clear the input to disable **Run async command**, then enter a work item and run it. The command captures its input before awaiting work. **Trigger failure** deliberately throws; `ThrownExceptions` delivers the error as a value, and the active view handles an `Interaction` to acknowledge it inline.
+3. Use **Back** and **Reset**. Navigation starts before the host attaches, exercising the initial-route regression. Leaving a page disposes its activation subscriptions and bindings; returning reconnects them.
+4. Close and reopen the application. Your input and threshold return. The small JSON file lives at `Environment.SpecialFolder.LocalApplicationData/ReactiveUI.Avalonia.Example/session.json`. Storage errors are reported in the sidebar, and the shutdown deferral is always released.
+
+`Program` composes the Microsoft DI provider and registers all views before it is built. The core, Autofac, DryIoc, Microsoft DI, and Ninject integrations are covered by the package tests; this single application chooses Microsoft DI to keep the walkthrough compact. The executable has no `ReactiveUI.Primitives.Reactive` or System.Reactive dependency.
+
+The matching headless TUnit project tests the production app configuration, routing, automatically resolved controls, actual button input, activation cleanup, UI-thread delivery, async errors, and session storage:
+
+```powershell
+dotnet test --project examples/ReactiveUI.Avalonia.Example.Tests/ReactiveUI.Avalonia.Example.Tests.csproj -c Release
+```
+
+The test executor awaits `Dispatch<bool>(Func<Task<bool>>)` and explicitly shares the application's dispatcher. Using an async delegate with the synchronous headless dispatch overload can return before assertions finish; recreating the dispatcher also invalidates cached UI schedulers. Session storage tests exercise persistence deferrals without shutting down the shared test dispatcher.

--- a/src/examples/ReactiveUI.Avalonia.Example/ReactiveUI.Avalonia.Example.csproj
+++ b/src/examples/ReactiveUI.Avalonia.Example/ReactiveUI.Avalonia.Example.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AssemblyName>ReactiveUI.Avalonia.Example</AssemblyName>
+    <RootNamespace>ReactiveUI.Avalonia.Example</RootNamespace>
+    <PackageDescription>Showcase application for the lean ReactiveUI.Avalonia integration.</PackageDescription>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia.Fonts.Inter" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="ReactiveUI" />
+    <PackageReference Include="ReactiveUI.Primitives" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ReactiveUI.Avalonia.Example.Tests" />
+    <ProjectReference Include="..\..\ReactiveUI.Avalonia\ReactiveUI.Avalonia.csproj" />
+    <ProjectReference Include="..\..\ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection\ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/examples/ReactiveUI.Avalonia.Example/Services/ILocalMachineMetricsService.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Services/ILocalMachineMetricsService.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Avalonia.Example.Models;
+
+namespace ReactiveUI.Avalonia.Example.Services;
+
+/// <summary>Provides live local machine measurements.</summary>
+public interface ILocalMachineMetricsService
+{
+    /// <summary>Reads a single local machine measurement.</summary>
+    /// <returns>The current local machine measurement.</returns>
+    MachineSnapshot ReadSnapshot();
+
+    /// <summary>Watches local machine measurements at the requested interval.</summary>
+    /// <param name="interval">The polling interval.</param>
+    /// <returns>An observable stream of local machine measurements.</returns>
+    IObservable<MachineSnapshot> Watch(TimeSpan interval);
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/Services/LocalMachineMetricsService.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Services/LocalMachineMetricsService.cs
@@ -1,0 +1,98 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using ReactiveUI.Avalonia.Example.Models;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Signals;
+
+namespace ReactiveUI.Avalonia.Example.Services;
+
+/// <summary>Samples process-local measurements from the current machine.</summary>
+public sealed class LocalMachineMetricsService : ILocalMachineMetricsService
+{
+    /// <summary>The number of bytes in one megabyte.</summary>
+    private const double BytesPerMegabyte = 1024D * 1024D;
+
+    /// <summary>The maximum percentage value.</summary>
+    private const double MaximumPercentage = 100D;
+
+    /// <summary>The gate protecting previous CPU sample values.</summary>
+    private readonly Lock _gate = new();
+
+    /// <summary>The time provider.</summary>
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>The previous total processor time.</summary>
+    private TimeSpan _lastProcessorTime;
+
+    /// <summary>The previous sample time.</summary>
+    private DateTimeOffset _lastSampleTime;
+
+    /// <summary>Initializes a new instance of the <see cref="LocalMachineMetricsService"/> class.</summary>
+    public LocalMachineMetricsService()
+        : this(TimeProvider.System)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="LocalMachineMetricsService"/> class.</summary>
+    /// <param name="timeProvider">The time provider.</param>
+    public LocalMachineMetricsService(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc/>
+    public MachineSnapshot ReadSnapshot()
+    {
+        using var process = Process.GetCurrentProcess();
+        var now = _timeProvider.GetLocalNow();
+        var cpuPercent = CalculateProcessorPercent(process.TotalProcessorTime, now);
+
+        return new(
+            now,
+            cpuPercent,
+            process.WorkingSet64 / BytesPerMegabyte,
+            GC.GetTotalMemory(false) / BytesPerMegabyte,
+            process.Threads.Count,
+            "Live local process data");
+    }
+
+    /// <inheritdoc/>
+    public IObservable<MachineSnapshot> Watch(TimeSpan interval) =>
+        Signal.Interval(interval)
+            .StartWith(0L)
+            .Select(_ => ReadSnapshot());
+
+    /// <summary>Calculates process CPU percentage from two local samples.</summary>
+    /// <param name="processorTime">The current total processor time.</param>
+    /// <param name="sampleTime">The current sample time.</param>
+    /// <returns>The estimated CPU percentage.</returns>
+    private double CalculateProcessorPercent(TimeSpan processorTime, DateTimeOffset sampleTime)
+    {
+        lock (_gate)
+        {
+            if (_lastSampleTime == default)
+            {
+                _lastProcessorTime = processorTime;
+                _lastSampleTime = sampleTime;
+                return 0;
+            }
+
+            var elapsedProcessor = processorTime - _lastProcessorTime;
+            var elapsedWall = sampleTime - _lastSampleTime;
+            _lastProcessorTime = processorTime;
+            _lastSampleTime = sampleTime;
+
+            if (elapsedWall <= TimeSpan.Zero)
+            {
+                return 0;
+            }
+
+            var processorCount = Math.Max(1, Environment.ProcessorCount);
+            var percentage = elapsedProcessor.TotalMilliseconds / elapsedWall.TotalMilliseconds / processorCount * MaximumPercentage;
+            return Math.Clamp(percentage, 0, MaximumPercentage);
+        }
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/Services/ShowcaseSession.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Services/ShowcaseSession.cs
@@ -1,0 +1,114 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Text.Json;
+using Avalonia.Controls.ApplicationLifetimes;
+using ReactiveUI;
+using ReactiveUI.Avalonia.Example.Models;
+using ReactiveUI.Avalonia.Example.ViewModels;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Disposables;
+
+namespace ReactiveUI.Avalonia.Example.Services;
+
+/// <summary>Composes Avalonia suspension notifications with a small local JSON settings store.</summary>
+public sealed class ShowcaseSession : IDisposable
+{
+    /// <summary>The view model whose settings are persisted.</summary>
+    private readonly MainViewModel _shell;
+
+    /// <summary>The settings file path.</summary>
+    private readonly string _path;
+
+    /// <summary>The platform lifetime adapter.</summary>
+    private readonly AutoSuspendHelper _suspension;
+
+    /// <summary>The lifetime subscriptions.</summary>
+    private readonly MultipleDisposable _subscriptions = new();
+
+    /// <summary>Initializes a new instance of the <see cref="ShowcaseSession"/> class.</summary>
+    /// <param name="lifetime">The running desktop lifetime.</param>
+    /// <param name="shell">The shell to persist.</param>
+    /// <param name="path">The settings file path.</param>
+    public ShowcaseSession(IApplicationLifetime lifetime, MainViewModel shell, string path)
+    {
+        _shell = shell;
+        _path = path;
+        _suspension = new(lifetime);
+        _subscriptions.Add(RxSuspension.SuspensionHost.IsLaunchingNew.SubscribeSafe(_ => Restore(), ReportFailure));
+        _subscriptions.Add(RxSuspension.SuspensionHost.ShouldPersistState.SubscribeSafe(Persist, ReportFailure));
+        _subscriptions.Add(RxSuspension.SuspensionHost.ShouldInvalidateState.SubscribeSafe(_ => Invalidate(), ReportFailure));
+    }
+
+    /// <summary>Signals startup after the shell and its services have been composed.</summary>
+    public void Start() => _suspension.OnFrameworkInitializationCompleted();
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _subscriptions.Dispose();
+        _suspension.Dispose();
+    }
+
+    /// <summary>Saves state and always releases the shutdown deferral.</summary>
+    /// <param name="deferral">The token allowing platform shutdown to finish.</param>
+    internal void Persist(IDisposable deferral)
+    {
+        using (deferral)
+        {
+            try
+            {
+                var state = new ShowcaseState(_shell.Commands.WorkItemText, _shell.Metrics.CpuWarningThreshold);
+                _ = Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(_path))!);
+                var temporaryPath = $"{_path}.tmp";
+                File.WriteAllText(temporaryPath, JsonSerializer.Serialize(state, ShowcaseJsonContext.Default.ShowcaseState));
+                File.Move(temporaryPath, _path, overwrite: true);
+                _shell.SessionStatus = "Session saved.";
+            }
+            catch (Exception error) when (error is IOException or UnauthorizedAccessException)
+            {
+                ReportFailure(error);
+            }
+        }
+    }
+
+    /// <summary>Restores the last session or reports a recoverable storage error.</summary>
+    private void Restore()
+    {
+        try
+        {
+            if (!File.Exists(_path))
+            {
+                _shell.SessionStatus = "New session. Input and threshold save on exit.";
+                return;
+            }
+
+            var state = JsonSerializer.Deserialize(File.ReadAllText(_path), ShowcaseJsonContext.Default.ShowcaseState)
+                ?? throw new JsonException("The saved session is empty.");
+            _shell.Commands.WorkItemText = state.WorkItemText ?? string.Empty;
+            _shell.Metrics.CpuWarningThreshold = state.CpuWarningThreshold;
+            _shell.SessionStatus = "Previous input and threshold restored.";
+        }
+        catch (Exception error) when (error is IOException or UnauthorizedAccessException or JsonException)
+        {
+            ReportFailure(error);
+        }
+    }
+
+    /// <summary>Removes settings after an unhandled application exception.</summary>
+    private void Invalidate()
+    {
+        try
+        {
+            File.Delete(_path);
+        }
+        catch (Exception error) when (error is IOException or UnauthorizedAccessException)
+        {
+            ReportFailure(error);
+        }
+    }
+
+    /// <summary>Surfaces storage failures in the shell.</summary>
+    /// <param name="error">The storage failure.</param>
+    private void ReportFailure(Exception error) => _shell.SessionStatus = $"Session storage: {error.Message}";
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/CommandLabViewModel.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/CommandLabViewModel.cs
@@ -1,0 +1,127 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using ReactiveUI;
+using ReactiveUI.Primitives;
+using Unit = ReactiveUI.Primitives.RxVoid;
+
+namespace ReactiveUI.Avalonia.Example.ViewModels;
+
+/// <summary>Demonstrates command can-execute, async execution, failure handling, and interactions.</summary>
+public sealed class CommandLabViewModel : PageViewModel
+{
+    /// <summary>The simulated command work delay.</summary>
+    private static readonly TimeSpan WorkDelay = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>The simulated failure delay.</summary>
+    private static readonly TimeSpan FailureDelay = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>The time provider.</summary>
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>Initializes a new instance of the <see cref="CommandLabViewModel"/> class.</summary>
+    /// <param name="hostScreen">The owning screen.</param>
+    [RequiresUnreferencedCode("This showcase uses WhenAnyValue to demonstrate command can-execute.")]
+    public CommandLabViewModel(IScreen hostScreen)
+        : this(hostScreen, TimeProvider.System)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="CommandLabViewModel"/> class.</summary>
+    /// <param name="hostScreen">The owning screen.</param>
+    /// <param name="timeProvider">The time provider.</param>
+    [RequiresUnreferencedCode("This showcase uses WhenAnyValue to demonstrate command can-execute.")]
+    public CommandLabViewModel(IScreen hostScreen, TimeProvider timeProvider)
+        : base(hostScreen, "commands", "Command lab", "Exercises ReactiveCommand can-execute, async work, thrown exceptions, and interactions.")
+    {
+        _timeProvider = timeProvider;
+        var canRun = this.WhenAnyValue(static x => x.WorkItemText, static text => !string.IsNullOrWhiteSpace(text));
+        RunWork = Track(ReactiveCommand.CreateFromTask(RunWorkAsync, canRun));
+        FailWork = Track(ReactiveCommand.CreateFromTask(FailWorkAsync));
+
+        _ = Track(RunWork.SubscribeSafe(result => LastResult = result, HandleError));
+        _ = Track(RunWork.ThrownExceptions.SubscribeSafe(HandleError, HandleError));
+        _ = Track(FailWork.ThrownExceptions.SubscribeSafe(HandleError, HandleError));
+    }
+
+    /// <summary>Gets the command that runs async work.</summary>
+    public ReactiveCommand<Unit, string> RunWork { get; }
+
+    /// <summary>Gets the command that intentionally fails.</summary>
+    public ReactiveCommand<Unit, Unit> FailWork { get; }
+
+    /// <summary>Gets the interaction used by the view to present command errors.</summary>
+    public Interaction<string, Unit> ReportError { get; } = new();
+
+    /// <summary>Gets or sets the command text input.</summary>
+    public string WorkItemText
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    } = string.Empty;
+
+    /// <summary>Gets or sets the last result text.</summary>
+    public string LastResult
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    } = "No command has run yet.";
+
+    /// <summary>Gets or sets the last error text.</summary>
+    public string LastError
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    } = "No errors reported.";
+
+    /// <summary>Gets or sets the interaction acknowledgement text.</summary>
+    public string InteractionStatus
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    } = "The view has not handled an interaction yet.";
+
+    /// <summary>Gets or sets the number of errors acknowledged by the view.</summary>
+    public int AcknowledgedErrors
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>Records that the view handled an error interaction.</summary>
+    /// <param name="message">The handled message.</param>
+    public void AcknowledgeError(string message)
+    {
+        AcknowledgedErrors++;
+        InteractionStatus = $"View acknowledged: {message}";
+    }
+
+    /// <summary>Intentionally fails to demonstrate command error flow.</summary>
+    /// <returns>A task representing the failing work.</returns>
+    private static async Task FailWorkAsync()
+    {
+        await Task.Delay(FailureDelay).ConfigureAwait(false);
+        throw new InvalidOperationException("The sample command failed by design.");
+    }
+
+    /// <summary>Runs the simulated async command work.</summary>
+    /// <returns>The command result text.</returns>
+    private async Task<string> RunWorkAsync()
+    {
+        var text = WorkItemText.Trim();
+        await Task.Delay(WorkDelay).ConfigureAwait(false);
+        return $"Processed '{text}' at {_timeProvider.GetLocalNow():T}.";
+    }
+
+    /// <summary>Handles command errors and notifies the interaction.</summary>
+    /// <param name="error">The command error.</param>
+    private void HandleError(Exception error)
+    {
+        LastError = error.Message;
+        _ = ReportError.Handle(error.Message).SubscribeSafe(
+            static _ => { },
+            interactionError => InteractionStatus = $"No active view handled the interaction: {interactionError.Message}");
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/FeatureViewModel.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/FeatureViewModel.cs
@@ -1,0 +1,8 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace ReactiveUI.Avalonia.Example.ViewModels;
+
+/// <summary>An immutable feature description resolved through an automatic item template.</summary>
+/// <param name="Name">The feature description.</param>
+public sealed record FeatureViewModel(string Name);

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/MainViewModel.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/MainViewModel.cs
@@ -1,0 +1,114 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using ReactiveUI;
+using ReactiveUI.Avalonia.Example.Services;
+using ReactiveUI.Primitives;
+using Unit = ReactiveUI.Primitives.RxVoid;
+
+namespace ReactiveUI.Avalonia.Example.ViewModels;
+
+/// <summary>Application shell view model.</summary>
+public sealed class MainViewModel : ViewModelBase, IScreen
+{
+    /// <summary>The overview page.</summary>
+    private OverviewViewModel _overview = null!;
+
+    /// <summary>Initializes a new instance of the <see cref="MainViewModel"/> class.</summary>
+    private MainViewModel()
+    {
+        ShowOverview = Track(ReactiveCommand.Create(() => Navigate(_overview)));
+        ShowMetrics = Track(ReactiveCommand.Create(() => Navigate(Metrics)));
+        ShowCommands = Track(ReactiveCommand.Create(() => Navigate(Commands)));
+        GoBack = Router.NavigateBack;
+        Reset = Track(ReactiveCommand.Create(ResetNavigation));
+    }
+
+    /// <inheritdoc/>
+    public RoutingState Router { get; } = new();
+
+    /// <summary>Gets the metrics page view model.</summary>
+    public MetricsViewModel Metrics { get; private set; } = null!;
+
+    /// <summary>Gets the commands page view model.</summary>
+    public CommandLabViewModel Commands { get; private set; } = null!;
+
+    /// <summary>Gets the command that navigates to the overview.</summary>
+    public ReactiveCommand<Unit, Unit> ShowOverview { get; }
+
+    /// <summary>Gets the command that navigates to the metrics page.</summary>
+    public ReactiveCommand<Unit, Unit> ShowMetrics { get; }
+
+    /// <summary>Gets the command that navigates to the command lab.</summary>
+    public ReactiveCommand<Unit, Unit> ShowCommands { get; }
+
+    /// <summary>Gets the command that navigates back.</summary>
+    public ReactiveCommand<Unit, IRoutableViewModel> GoBack { get; }
+
+    /// <summary>Gets the command that resets navigation.</summary>
+    public ReactiveCommand<Unit, Unit> Reset { get; }
+
+    /// <summary>Gets or sets the navigation status.</summary>
+    public string NavigationStatus
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    } = "Navigation is ready.";
+
+    /// <summary>Gets or sets the current persistence status.</summary>
+    public string SessionStatus
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, value);
+    } = "Session persistence starts with the desktop lifetime.";
+
+    /// <summary>Creates an initialized shell view model.</summary>
+    /// <param name="metricsService">The local metrics service.</param>
+    /// <returns>The initialized shell view model.</returns>
+    [RequiresUnreferencedCode("The shell creates showcase pages that intentionally use ReactiveUI expression-based helpers.")]
+    public static MainViewModel Create(ILocalMachineMetricsService metricsService)
+    {
+        var viewModel = new MainViewModel();
+        viewModel.Initialize(metricsService);
+        return viewModel;
+    }
+
+    /// <summary>Navigates to a page.</summary>
+    /// <param name="page">The page to navigate to.</param>
+    public void Navigate(IRoutableViewModel page) => _ = Router.Navigate.Execute(page).SubscribeSafe(
+        routed => NavigationStatus = $"Navigated to {routed.UrlPathSegment}.",
+        HandleNavigationError);
+
+    /// <summary>Resets the navigation stack to the overview page.</summary>
+    public void ResetNavigation() => _ = Router.NavigateAndReset.Execute(_overview).SubscribeSafe(
+        routed => NavigationStatus = $"Reset to {routed.UrlPathSegment}.",
+        HandleNavigationError);
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _overview.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    /// <summary>Handles navigation errors.</summary>
+    /// <param name="error">The navigation error.</param>
+    private void HandleNavigationError(Exception error) => NavigationStatus = error.Message;
+
+    /// <summary>Initializes routed pages after construction.</summary>
+    /// <param name="metricsService">The local metrics service.</param>
+    [RequiresUnreferencedCode("The shell creates showcase pages that intentionally use ReactiveUI expression-based helpers.")]
+    private void Initialize(ILocalMachineMetricsService metricsService)
+    {
+        _overview = new(this);
+        Metrics = Track(new MetricsViewModel(this, metricsService));
+        Commands = Track(new CommandLabViewModel(this));
+        ResetNavigation();
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/MetricCardViewModel.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/MetricCardViewModel.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+
+namespace ReactiveUI.Avalonia.Example.ViewModels;
+
+/// <summary>View model for a reusable metric card resolved by contract.</summary>
+public sealed class MetricCardViewModel : ReactiveObject
+{
+    /// <summary>The value text.</summary>
+    private string _value;
+
+    /// <summary>Initializes a new instance of the <see cref="MetricCardViewModel"/> class.</summary>
+    /// <param name="title">The card title.</param>
+    /// <param name="value">The value text.</param>
+    /// <param name="caption">The caption text.</param>
+    public MetricCardViewModel(string title, string value, string caption)
+    {
+        Title = title;
+        _value = value;
+        Caption = caption;
+    }
+
+    /// <summary>Gets the card title.</summary>
+    public string Title { get; }
+
+    /// <summary>Gets or sets the value text.</summary>
+    public string Value
+    {
+        get => _value;
+        set => this.RaiseAndSetIfChanged(ref _value, value);
+    }
+
+    /// <summary>Gets the caption text.</summary>
+    public string Caption { get; }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/MetricsViewModel.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/MetricsViewModel.cs
@@ -1,0 +1,126 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using ReactiveUI;
+using ReactiveUI.Avalonia.Example.Models;
+using ReactiveUI.Avalonia.Example.Services;
+using ReactiveUI.Primitives;
+using Unit = ReactiveUI.Primitives.RxVoid;
+
+namespace ReactiveUI.Avalonia.Example.ViewModels;
+
+/// <summary>Shows live local process measurements.</summary>
+public sealed class MetricsViewModel : PageViewModel
+{
+    /// <summary>The maximum percentage value.</summary>
+    private const double MaximumPercentage = 100D;
+
+    /// <summary>The local metrics service.</summary>
+    private readonly ILocalMachineMetricsService _metricsService;
+
+    /// <summary>The computed load label backing field.</summary>
+    private readonly ObservableAsPropertyHelper<string> _loadLabel;
+
+    /// <summary>Initializes a new instance of the <see cref="MetricsViewModel"/> class.</summary>
+    /// <param name="hostScreen">The owning screen.</param>
+    /// <param name="metricsService">The local metrics service.</param>
+    [RequiresUnreferencedCode("This showcase uses WhenAnyValue and ToProperty to demonstrate ObservableAsPropertyHelper.")]
+    public MetricsViewModel(IScreen hostScreen, ILocalMachineMetricsService metricsService)
+        : base(hostScreen, "metrics", "Live local metrics", "Samples this process and updates the UI while the page is active.")
+    {
+        _metricsService = metricsService;
+        ProcessorCard = new("Process CPU", "0.0%", "Estimated from process CPU time deltas");
+        MemoryCard = new("Working set", "0.0 MB", "Current process resident memory");
+        ManagedCard = new("Managed heap", "0.0 MB", "GC.GetTotalMemory without forcing collection");
+        SampleOnce = Track(ReactiveCommand.CreateFromTask(SampleOnceAsync));
+        _ = Track(SampleOnce.ThrownExceptions.SubscribeSafe(ApplyError, ApplyError));
+
+        _loadLabel = this.WhenAnyValue(
+            static x => x.Latest.ProcessorPercent,
+            static x => x.CpuWarningThreshold,
+            static (cpu, threshold) => cpu >= threshold ? "CPU is at or above the warning threshold." : "CPU is below the warning threshold.")
+            .ToProperty(this, static x => x.LoadLabel, "Waiting for live data.");
+
+        this.WhenActivated(disposables =>
+        {
+            _ = _metricsService
+                .Watch(TimeSpan.FromSeconds(1))
+                .ObserveOn(RxSchedulers.MainThreadScheduler)
+                .SubscribeSafe(ApplySnapshot, ApplyError)
+                .DisposeWith(disposables);
+        });
+    }
+
+    /// <summary>Gets the CPU metric card.</summary>
+    public MetricCardViewModel ProcessorCard { get; }
+
+    /// <summary>Gets the memory metric card.</summary>
+    public MetricCardViewModel MemoryCard { get; }
+
+    /// <summary>Gets the managed heap metric card.</summary>
+    public MetricCardViewModel ManagedCard { get; }
+
+    /// <summary>Gets the command that reads one immediate sample.</summary>
+    public ReactiveCommand<Unit, MachineSnapshot> SampleOnce { get; }
+
+    /// <summary>Gets the computed load label.</summary>
+    public string LoadLabel => _loadLabel.Value;
+
+    /// <summary>Gets the latest sample.</summary>
+    public MachineSnapshot Latest
+    {
+        get;
+        private set => this.RaiseAndSetIfChanged(ref field, value);
+    } = MachineSnapshot.Empty;
+
+    /// <summary>Gets or sets the CPU warning threshold.</summary>
+    public double CpuWarningThreshold
+    {
+        get;
+        set => this.RaiseAndSetIfChanged(ref field, Math.Clamp(value, 1, MaximumPercentage));
+    } = 40;
+
+    /// <summary>Gets the number of observed live samples.</summary>
+    public int SampleCount
+    {
+        get;
+        private set => this.RaiseAndSetIfChanged(ref field, value);
+    }
+
+    /// <summary>Applies a deterministic sample for tests and immediate UI refreshes.</summary>
+    /// <param name="snapshot">The sample to apply.</param>
+    public void ApplySnapshot(MachineSnapshot snapshot)
+    {
+        Latest = snapshot;
+        SampleCount++;
+        ProcessorCard.Value = $"{snapshot.ProcessorPercent:0.0}%";
+        MemoryCard.Value = $"{snapshot.WorkingSetMegabytes:0.0} MB";
+        ManagedCard.Value = $"{snapshot.ManagedMegabytes:0.0} MB";
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _loadLabel.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    /// <summary>Reads and applies one immediate sample.</summary>
+    /// <returns>The applied sample.</returns>
+    private Task<MachineSnapshot> SampleOnceAsync()
+    {
+        var snapshot = _metricsService.ReadSnapshot();
+        ApplySnapshot(snapshot);
+        return Task.FromResult(snapshot);
+    }
+
+    /// <summary>Applies an error sample when the live feed fails.</summary>
+    /// <param name="error">The live feed error.</param>
+    private void ApplyError(Exception error) => Latest = Latest with { Status = error.Message };
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/OverviewViewModel.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/OverviewViewModel.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+
+namespace ReactiveUI.Avalonia.Example.ViewModels;
+
+/// <summary>Introduces the showcase features.</summary>
+public sealed class OverviewViewModel : PageViewModel
+{
+    /// <summary>Initializes a new instance of the <see cref="OverviewViewModel"/> class.</summary>
+    /// <param name="hostScreen">The owning screen.</param>
+    public OverviewViewModel(IScreen hostScreen)
+        : base(hostScreen, "overview", "ReactiveUI.Avalonia showcase", "A compact tour through routing, binding, activation, interactions, and live local data.")
+    {
+    }
+
+    /// <summary>Gets feature labels rendered by the overview page.</summary>
+    public IReadOnlyList<FeatureViewModel> Features { get; } =
+    [
+        new("RoutedViewHost shell navigation"),
+        new("ViewModelViewHost contracts and automatic item templates"),
+        new("ReactiveUI Bind, OneWayBind, and Avalonia compiled bindings"),
+        new("ReactiveCommand can-execute, async execution, and failures"),
+        new("ObservableAsPropertyHelper computed state"),
+        new("WhenActivated disposal for live subscriptions"),
+        new("GetSubject and GetBindingSubject property bridges"),
+        new("AutoSuspendHelper restores input and threshold between sessions")
+    ];
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/PageViewModel.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/PageViewModel.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+
+namespace ReactiveUI.Avalonia.Example.ViewModels;
+
+/// <summary>Base routed page view model.</summary>
+public class PageViewModel : ViewModelBase, IRoutableViewModel
+{
+    /// <summary>Initializes a new instance of the <see cref="PageViewModel"/> class.</summary>
+    /// <param name="hostScreen">The owning screen.</param>
+    /// <param name="urlPathSegment">The route segment.</param>
+    /// <param name="title">The display title.</param>
+    /// <param name="summary">The page summary.</param>
+    protected PageViewModel(IScreen hostScreen, string urlPathSegment, string title, string summary)
+    {
+        HostScreen = hostScreen;
+        UrlPathSegment = urlPathSegment;
+        Title = title;
+        Summary = summary;
+    }
+
+    /// <inheritdoc/>
+    public string UrlPathSegment { get; }
+
+    /// <inheritdoc/>
+    public IScreen HostScreen { get; }
+
+    /// <summary>Gets the display title.</summary>
+    public string Title { get; }
+
+    /// <summary>Gets the page summary.</summary>
+    public string Summary { get; }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/ViewModelBase.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/ViewModelBase.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+using ReactiveUI.Primitives.Disposables;
+
+namespace ReactiveUI.Avalonia.Example.ViewModels;
+
+/// <summary>Base view model with ReactiveUI activation support.</summary>
+public class ViewModelBase : ReactiveObject, IActivatableViewModel, IDisposable
+{
+    /// <summary>The disposables owned by the view model.</summary>
+    private readonly MultipleDisposable _disposables = new();
+
+    /// <summary>A value indicating whether this instance has been disposed.</summary>
+    private bool _disposed;
+
+    /// <summary>Initializes a new instance of the <see cref="ViewModelBase"/> class.</summary>
+    protected ViewModelBase() => _disposables.Add(Activator);
+
+    /// <inheritdoc/>
+    public ViewModelActivator Activator { get; } = new();
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Disposes managed resources.</summary>
+    /// <param name="disposing">A value indicating whether managed resources should be disposed.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposing)
+        {
+            return;
+        }
+
+        _disposables.Dispose();
+    }
+
+    /// <summary>Tracks a disposable for the view-model lifetime.</summary>
+    /// <typeparam name="TDisposable">The disposable type.</typeparam>
+    /// <param name="disposable">The disposable to track.</param>
+    /// <returns>The tracked disposable.</returns>
+    protected TDisposable Track<TDisposable>(TDisposable disposable)
+        where TDisposable : IDisposable
+    {
+        _disposables.Add(disposable);
+        return disposable;
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/CommandLabView.axaml
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/CommandLabView.axaml
@@ -1,0 +1,49 @@
+<rxui:ReactiveUserControl
+    x:Class="ReactiveUI.Avalonia.Example.Views.CommandLabView"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:rxui="using:ReactiveUI.Avalonia"
+    xmlns:vm="using:ReactiveUI.Avalonia.Example.ViewModels"
+    x:DataType="vm:CommandLabViewModel">
+    <ScrollViewer>
+        <StackPanel Margin="40" Spacing="20">
+            <StackPanel Spacing="8">
+                <TextBlock Classes="eyebrow" Text="COMMANDS AND INTERACTIONS" />
+                <TextBlock Classes="title" Text="{Binding Title}" />
+                <TextBlock Classes="subtitle" Text="{Binding Summary}" />
+            </StackPanel>
+
+            <Border Classes="panel">
+                <StackPanel Spacing="14">
+                    <TextBlock FontWeight="SemiBold" Text="Async command input" />
+                    <TextBox
+                        x:Name="WorkItemTextBox"
+                        PlaceholderText="Type a small work item"
+                        Text="" />
+                    <StackPanel Orientation="Horizontal" Spacing="10">
+                        <Button
+                            x:Name="RunWorkButton"
+                            Classes="primary"
+                            Content="Run async command" />
+                        <Button
+                            x:Name="FailWorkButton"
+                            Content="Trigger failure" />
+                    </StackPanel>
+                    <TextBlock x:Name="LastResultText" Classes="subtitle" />
+                    <Border
+                        Background="#FEF2F2"
+                        BorderBrush="#FECACA"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Padding="12">
+                        <TextBlock
+                            x:Name="LastErrorText"
+                            Foreground="#991B1B"
+                            TextWrapping="Wrap" />
+                    </Border>
+                    <TextBlock x:Name="InteractionStatusText" Classes="subtitle" />
+                </StackPanel>
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
+</rxui:ReactiveUserControl>

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/CommandLabView.axaml.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/CommandLabView.axaml.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using ReactiveUI;
+using ReactiveUI.Avalonia.Example.ViewModels;
+using Unit = ReactiveUI.Primitives.RxVoid;
+
+namespace ReactiveUI.Avalonia.Example.Views;
+
+/// <summary>The routed command lab view.</summary>
+public sealed partial class CommandLabView : ReactiveUserControl<CommandLabViewModel>
+{
+    /// <summary>Initializes a new instance of the <see cref="CommandLabView"/> class.</summary>
+    [RequiresUnreferencedCode("The view uses reflection-based ReactiveUI binding and activation.")]
+    [RequiresDynamicCode("The view uses dynamic ReactiveUI property bindings.")]
+    public CommandLabView()
+    {
+        InitializeComponent();
+        _ = this.WhenActivated(BindView);
+    }
+
+    /// <summary>Creates bindings owned by this activation.</summary>
+    /// <param name="disposables">The activation lifetime.</param>
+    [RequiresUnreferencedCode("The view uses reflection-based ReactiveUI bindings.")]
+    [RequiresDynamicCode("The view uses dynamic ReactiveUI property bindings.")]
+    private void BindView(ReactiveUI.Primitives.Disposables.MultipleDisposable disposables)
+    {
+        disposables.Add(this.Bind(ViewModel, static viewModel => viewModel.WorkItemText, static view => view.WorkItemTextBox.Text));
+
+        disposables.Add(this.OneWayBind(ViewModel, static viewModel => viewModel.LastResult, static view => view.LastResultText.Text));
+
+        disposables.Add(this.OneWayBind(ViewModel, static viewModel => viewModel.LastError, static view => view.LastErrorText.Text));
+
+        disposables.Add(this.OneWayBind(ViewModel, static viewModel => viewModel.InteractionStatus, static view => view.InteractionStatusText.Text));
+
+        disposables.Add(this.BindCommand(ViewModel, static viewModel => viewModel.RunWork, static view => view.RunWorkButton));
+
+        disposables.Add(this.BindCommand(ViewModel, static viewModel => viewModel.FailWork, static view => view.FailWorkButton));
+
+        if (ViewModel is null)
+        {
+            return;
+        }
+
+        disposables.Add(ViewModel.ReportError.RegisterHandler(context =>
+        {
+            ViewModel.AcknowledgeError(context.Input);
+            context.SetOutput(Unit.Default);
+        }));
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/FeatureView.axaml
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/FeatureView.axaml
@@ -1,0 +1,11 @@
+<rxui:ReactiveUserControl
+    x:Class="ReactiveUI.Avalonia.Example.Views.FeatureView"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:rxui="using:ReactiveUI.Avalonia"
+    xmlns:vm="using:ReactiveUI.Avalonia.Example.ViewModels"
+    x:DataType="vm:FeatureViewModel">
+    <Border BorderBrush="#E5E7EB" BorderThickness="0,0,0,1" Padding="0,12">
+        <TextBlock FontSize="15" Foreground="#111827" TextWrapping="Wrap" Text="{Binding Name}" />
+    </Border>
+</rxui:ReactiveUserControl>

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/FeatureView.axaml.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/FeatureView.axaml.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Diagnostics.CodeAnalysis;
+using ReactiveUI.Avalonia.Example.ViewModels;
+
+namespace ReactiveUI.Avalonia.Example.Views;
+
+/// <summary>A reusable feature row resolved by the automatic data-template binding hook.</summary>
+public sealed partial class FeatureView : ReactiveUserControl<FeatureViewModel>
+{
+    /// <summary>Initializes a new instance of the <see cref="FeatureView"/> class.</summary>
+    [RequiresUnreferencedCode("The reactive control wires reflection-based activation.")]
+    public FeatureView() => InitializeComponent();
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/MainWindow.axaml
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/MainWindow.axaml
@@ -1,0 +1,68 @@
+<rxui:ReactiveWindow
+    x:Class="ReactiveUI.Avalonia.Example.Views.MainWindow"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:rxui="using:ReactiveUI.Avalonia"
+    xmlns:vm="using:ReactiveUI.Avalonia.Example.ViewModels"
+    Width="1180"
+    Height="760"
+    MinWidth="940"
+    MinHeight="620"
+    Classes="showcase"
+    Title="ReactiveUI.Avalonia Example"
+    x:DataType="vm:MainViewModel">
+    <Grid ColumnDefinitions="280,*">
+        <ThemeVariantScope Grid.Column="0" RequestedThemeVariant="Dark">
+            <Border
+                Background="#111827"
+                Padding="24">
+                <DockPanel LastChildFill="True">
+                    <StackPanel DockPanel.Dock="Top" Spacing="8">
+                        <TextBlock
+                            Foreground="#F9FAFB"
+                            FontSize="22"
+                            FontWeight="SemiBold"
+                            Text="ReactiveUI.Avalonia" />
+                        <TextBlock
+                            Foreground="#CBD5E1"
+                            TextWrapping="Wrap"
+                            Text="Lean package showcase with routing, live data, and activation." />
+                    </StackPanel>
+
+                    <StackPanel DockPanel.Dock="Bottom">
+                        <TextBlock
+                            Margin="0,0,0,18"
+                            Foreground="#CBD5E1"
+                            Text="{Binding SessionStatus}"
+                            TextWrapping="Wrap" />
+                        <TextBlock
+                            Margin="0,0,0,12"
+                            Foreground="#CBD5E1"
+                            Text="{Binding NavigationStatus}"
+                            TextWrapping="Wrap" />
+                        <Button Classes="nav" Command="{Binding GoBack}" Content="Back" />
+                        <Button Classes="nav" Command="{Binding Reset}" Content="Reset" />
+                    </StackPanel>
+
+                    <StackPanel Margin="0,116,0,0">
+                        <Button Classes="nav" Command="{Binding ShowOverview}" Content="Overview" />
+                        <Button Classes="nav" Command="{Binding ShowMetrics}" Content="Live metrics" />
+                        <Button Classes="nav" Command="{Binding ShowCommands}" Content="Command lab" />
+                    </StackPanel>
+                </DockPanel>
+            </Border>
+            </ThemeVariantScope>
+
+        <rxui:RoutedViewHost
+            x:Name="RouterHost"
+            Grid.Column="1"
+            Margin="0"
+            Router="{Binding Router}">
+            <rxui:RoutedViewHost.DefaultContent>
+                <Border Classes="panel" Margin="32">
+                    <TextBlock Text="Select a route to begin." />
+                </Border>
+            </rxui:RoutedViewHost.DefaultContent>
+        </rxui:RoutedViewHost>
+    </Grid>
+</rxui:ReactiveWindow>

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/MainWindow.axaml.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/MainWindow.axaml.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using ReactiveUI.Avalonia.Example.ViewModels;
+
+namespace ReactiveUI.Avalonia.Example.Views;
+
+/// <summary>The main example shell window.</summary>
+public sealed partial class MainWindow : ReactiveWindow<MainViewModel>
+{
+    /// <summary>Initializes a new instance of the <see cref="MainWindow"/> class.</summary>
+    [RequiresUnreferencedCode("ReactiveWindow activation evaluates expression-based member chains via reflection.")]
+    [RequiresDynamicCode("ReactiveWindow activation may require dynamic binding invocation.")]
+    public MainWindow()
+    {
+        InitializeComponent();
+        Closed += OnClosed;
+    }
+
+    /// <summary>Disposes the view model when the shell closes.</summary>
+    /// <param name="sender">The event sender.</param>
+    /// <param name="e">The event data.</param>
+    private void OnClosed(object? sender, EventArgs e) => ViewModel?.Dispose();
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/MemoryMetricCardView.axaml
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/MemoryMetricCardView.axaml
@@ -1,0 +1,18 @@
+<rxui:ReactiveUserControl
+    x:Class="ReactiveUI.Avalonia.Example.Views.MemoryMetricCardView"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:rxui="using:ReactiveUI.Avalonia"
+    xmlns:vm="using:ReactiveUI.Avalonia.Example.ViewModels"
+    x:DataType="vm:MetricCardViewModel">
+    <Border
+        Classes="panel"
+        BorderBrush="#D1FAE5"
+        Background="#ECFDF5">
+        <StackPanel Spacing="8">
+            <TextBlock Classes="eyebrow" Text="{Binding Title}" />
+            <TextBlock Classes="metricValue" Text="{Binding Value}" />
+            <TextBlock Classes="subtitle" Text="{Binding Caption}" />
+        </StackPanel>
+    </Border>
+</rxui:ReactiveUserControl>

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/MemoryMetricCardView.axaml.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/MemoryMetricCardView.axaml.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using ReactiveUI.Avalonia.Example.ViewModels;
+
+namespace ReactiveUI.Avalonia.Example.Views;
+
+/// <summary>A contracted metric card view for memory metrics.</summary>
+public sealed partial class MemoryMetricCardView : ReactiveUserControl<MetricCardViewModel>
+{
+    /// <summary>Initializes a new instance of the <see cref="MemoryMetricCardView"/> class.</summary>
+    [RequiresUnreferencedCode("ReactiveUserControl activation evaluates expression-based member chains via reflection.")]
+    public MemoryMetricCardView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/MetricsView.axaml
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/MetricsView.axaml
@@ -1,0 +1,84 @@
+<rxui:ReactiveUserControl
+    x:Class="ReactiveUI.Avalonia.Example.Views.MetricsView"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:rxui="using:ReactiveUI.Avalonia"
+    xmlns:vm="using:ReactiveUI.Avalonia.Example.ViewModels"
+    x:DataType="vm:MetricsViewModel">
+    <ScrollViewer>
+        <StackPanel Margin="40" Spacing="20">
+            <StackPanel Spacing="8">
+                <TextBlock Classes="eyebrow" Text="LIVE LOCAL DATA" />
+                <TextBlock Classes="title" Text="{Binding Title}" />
+                <TextBlock Classes="subtitle" Text="{Binding Summary}" />
+            </StackPanel>
+
+            <Grid ColumnDefinitions="*,*,*" ColumnSpacing="16">
+                <rxui:ViewModelViewHost
+                    Grid.Column="0"
+                    ViewContract="performance"
+                    ViewModel="{Binding ProcessorCard}" />
+                <rxui:ViewModelViewHost
+                    Grid.Column="1"
+                    ViewContract="memory"
+                    ViewModel="{Binding MemoryCard}" />
+                <rxui:ViewModelViewHost
+                    Grid.Column="2"
+                    ViewContract="memory"
+                    ViewModel="{Binding ManagedCard}" />
+            </Grid>
+
+            <Border Classes="panel">
+                <Grid ColumnDefinitions="2*,*" ColumnSpacing="24">
+                    <StackPanel Spacing="12">
+                        <TextBlock FontWeight="SemiBold" Text="CPU warning threshold" />
+                        <Slider
+                            x:Name="ThresholdSlider"
+                            Minimum="1"
+                            Maximum="100"
+                            Value="{Binding CpuWarningThreshold, Mode=TwoWay}" />
+                        <TextBlock Classes="subtitle" Text="{Binding LoadLabel}" />
+                    </StackPanel>
+
+                    <Border
+                        x:Name="ThresholdPreview"
+                        Grid.Column="1"
+                        Background="#1F6FEB"
+                        CornerRadius="8"
+                        MinHeight="92">
+                        <StackPanel
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Spacing="4">
+                            <TextBlock
+                                HorizontalAlignment="Center"
+                                FontSize="26"
+                                FontWeight="SemiBold"
+                                Foreground="White"
+                                Text="{Binding CpuWarningThreshold, StringFormat='{}{0:0}%'}" />
+                            <TextBlock
+                                HorizontalAlignment="Center"
+                                Foreground="#E5E7EB"
+                                Text="GetSubject preview" />
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </Border>
+
+            <Border Classes="panel">
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
+                    <StackPanel Spacing="4">
+                        <TextBlock FontWeight="SemiBold" Text="{Binding Latest.Status}" />
+                        <TextBlock Classes="subtitle" Text="{Binding Latest.CapturedAt, StringFormat='Last sample: {0:T}'}" />
+                        <TextBlock Classes="subtitle" Text="{Binding SampleCount, StringFormat='Samples observed while active: {0}'}" />
+                    </StackPanel>
+                    <Button
+                        Grid.Column="1"
+                        Classes="primary"
+                        Command="{Binding SampleOnce}"
+                        Content="Sample now" />
+                </Grid>
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
+</rxui:ReactiveUserControl>

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/MetricsView.axaml.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/MetricsView.axaml.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Avalonia;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using ReactiveUI.Avalonia.Example.ViewModels;
+using ReactiveUI.Primitives;
+
+namespace ReactiveUI.Avalonia.Example.Views;
+
+/// <summary>The routed metrics view.</summary>
+public sealed partial class MetricsView : ReactiveUserControl<MetricsViewModel>
+{
+    /// <summary>The minimum preview opacity.</summary>
+    private const double MinimumPreviewOpacity = 0.35D;
+
+    /// <summary>The preview opacity range.</summary>
+    private const double PreviewOpacityRange = 0.65D;
+
+    /// <summary>The maximum percentage value.</summary>
+    private const double MaximumPercentage = 100D;
+
+    /// <summary>Initializes a new instance of the <see cref="MetricsView"/> class.</summary>
+    [RequiresUnreferencedCode("The view uses reflection-based ReactiveUI activation.")]
+    public MetricsView()
+    {
+        InitializeComponent();
+        _ = this.WhenActivated(disposables =>
+        {
+            var preview = ThresholdPreview.GetBindingSubject(Visual.OpacityProperty);
+            disposables.Add(ThresholdSlider
+                .GetSubject(RangeBase.ValueProperty)
+                .Select(static value => new BindingValue<double>(MinimumPreviewOpacity + (value / MaximumPercentage * PreviewOpacityRange)))
+                .SubscribeSafe(preview.OnNext, static error => throw error));
+        });
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/OverviewView.axaml
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/OverviewView.axaml
@@ -1,0 +1,21 @@
+<rxui:ReactiveUserControl
+    x:Class="ReactiveUI.Avalonia.Example.Views.OverviewView"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:rxui="using:ReactiveUI.Avalonia"
+    xmlns:vm="using:ReactiveUI.Avalonia.Example.ViewModels"
+    x:DataType="vm:OverviewViewModel">
+    <ScrollViewer>
+        <StackPanel Margin="40" Spacing="20">
+            <StackPanel Spacing="8">
+                <TextBlock Classes="eyebrow" Text="OVERVIEW" />
+                <TextBlock Classes="title" Text="{Binding Title}" />
+                <TextBlock Classes="subtitle" Text="{Binding Summary}" />
+            </StackPanel>
+
+            <Border Classes="panel">
+                <ItemsControl x:Name="FeatureItems" />
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
+</rxui:ReactiveUserControl>

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/OverviewView.axaml.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/OverviewView.axaml.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using ReactiveUI;
+using ReactiveUI.Avalonia.Example.ViewModels;
+using ReactiveUI.Primitives.Disposables;
+
+namespace ReactiveUI.Avalonia.Example.Views;
+
+/// <summary>The routed overview view.</summary>
+public sealed partial class OverviewView : ReactiveUserControl<OverviewViewModel>
+{
+    /// <summary>Initializes a new instance of the <see cref="OverviewView"/> class.</summary>
+    [RequiresUnreferencedCode("ReactiveUserControl activation evaluates expression-based member chains via reflection.")]
+    [RequiresDynamicCode("The feature list uses expression-based ReactiveUI binding.")]
+    public OverviewView()
+    {
+        InitializeComponent();
+        _ = this.WhenActivated(BindView);
+    }
+
+    /// <summary>Binds items while the overview is active, allowing the automatic template hook to resolve rows.</summary>
+    /// <param name="disposables">The current activation lifetime.</param>
+    [RequiresUnreferencedCode("The feature list uses reflection-based property binding.")]
+    [RequiresDynamicCode("The feature list uses dynamic ReactiveUI binding.")]
+    private void BindView(MultipleDisposable disposables) =>
+        disposables.Add(this.OneWayBind(ViewModel, static model => model.Features, static view => view.FeatureItems.ItemsSource));
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/PerformanceMetricCardView.axaml
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/PerformanceMetricCardView.axaml
@@ -1,0 +1,18 @@
+<rxui:ReactiveUserControl
+    x:Class="ReactiveUI.Avalonia.Example.Views.PerformanceMetricCardView"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:rxui="using:ReactiveUI.Avalonia"
+    xmlns:vm="using:ReactiveUI.Avalonia.Example.ViewModels"
+    x:DataType="vm:MetricCardViewModel">
+    <Border
+        Classes="panel"
+        BorderBrush="#BFDBFE"
+        Background="#EFF6FF">
+        <StackPanel Spacing="8">
+            <TextBlock Classes="eyebrow" Text="{Binding Title}" />
+            <TextBlock Classes="metricValue" Text="{Binding Value}" />
+            <TextBlock Classes="subtitle" Text="{Binding Caption}" />
+        </StackPanel>
+    </Border>
+</rxui:ReactiveUserControl>

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/PerformanceMetricCardView.axaml.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/PerformanceMetricCardView.axaml.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using ReactiveUI.Avalonia.Example.ViewModels;
+
+namespace ReactiveUI.Avalonia.Example.Views;
+
+/// <summary>A contracted metric card view for performance metrics.</summary>
+public sealed partial class PerformanceMetricCardView : ReactiveUserControl<MetricCardViewModel>
+{
+    /// <summary>Initializes a new instance of the <see cref="PerformanceMetricCardView"/> class.</summary>
+    [RequiresUnreferencedCode("ReactiveUserControl activation evaluates expression-based member chains via reflection.")]
+    public PerformanceMetricCardView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/ShowcaseStyles.axaml
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/ShowcaseStyles.axaml
@@ -1,0 +1,58 @@
+<Styles xmlns="https://github.com/avaloniaui">
+    <Design.PreviewWith>
+        <Border Padding="24" />
+    </Design.PreviewWith>
+
+    <Style Selector="Window.showcase">
+        <Setter Property="Background" Value="#F4F6F8" />
+        <Setter Property="FontFamily" Value="Inter, Segoe UI" />
+    </Style>
+
+    <Style Selector="Button.nav">
+        <Setter Property="Foreground" Value="#F9FAFB" />
+        <Setter Property="Background" Value="#334155" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="Padding" Value="14,10" />
+        <Setter Property="Margin" Value="0,0,0,8" />
+        <Setter Property="CornerRadius" Value="8" />
+    </Style>
+
+    <Style Selector="Button.primary">
+        <Setter Property="Padding" Value="16,10" />
+        <Setter Property="CornerRadius" Value="8" />
+        <Setter Property="Background" Value="#1F6FEB" />
+        <Setter Property="Foreground" Value="White" />
+    </Style>
+
+    <Style Selector="Border.panel">
+        <Setter Property="Background" Value="White" />
+        <Setter Property="BorderBrush" Value="#D8DEE6" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="8" />
+        <Setter Property="Padding" Value="20" />
+    </Style>
+
+    <Style Selector="TextBlock.eyebrow">
+        <Setter Property="Foreground" Value="#586069" />
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+
+    <Style Selector="TextBlock.title">
+        <Setter Property="FontSize" Value="28" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Foreground" Value="#111827" />
+    </Style>
+
+    <Style Selector="TextBlock.subtitle">
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="Foreground" Value="#4B5563" />
+        <Setter Property="TextWrapping" Value="Wrap" />
+    </Style>
+
+    <Style Selector="TextBlock.metricValue">
+        <Setter Property="FontSize" Value="26" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Foreground" Value="#111827" />
+    </Style>
+</Styles>

--- a/src/examples/ReactiveUI.Avalonia.Example/app.manifest
+++ b/src/examples/ReactiveUI.Avalonia.Example/app.manifest
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="ReactiveUI.Avalonia.Example" />
+</assembly>

--- a/src/tests/ReactiveUI.Avalonia.DryIoc1.Tests/AvaloniaMixinsDryIocMoreTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.DryIoc1.Tests/AvaloniaMixinsDryIocMoreTests.cs
@@ -4,6 +4,8 @@
 using Avalonia;
 using DryIoc;
 using ReactiveUI.Avalonia.Splat;
+using ReactiveUI.Builder;
+using Splat;
 using Splat.DryIoc;
 
 namespace ReactiveUI.Avalonia.DryIoc.Tests;
@@ -39,5 +41,77 @@ public class AvaloniaMixinsDryIocMoreTests
             static _ => { });
 
         await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    /// <summary>Verifies that null container configuration is validated by the deferred callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithDryIoc_AfterPlatformCallback_ThrowsOnNullContainerConfig()
+    {
+        var builder = AppBuilder.Configure<Application>();
+        _ = AvaloniaMixins.UseReactiveUIWithDryIoc(builder, null!, null);
+
+        await Assert.That(() => builder.AfterPlatformServicesSetupCallback!(builder))
+            .ThrowsExactly<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that DryIoc registration executes through the deferred platform setup callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithDryIoc_AfterPlatformCallback_ConfiguresContainer()
+    {
+        ReactiveUIBuilder.ResetBuilderStateForTests();
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+        var reactiveBuilderCalled = false;
+        var originalLocator = Locator.GetLocator();
+
+        try
+        {
+            _ = AvaloniaMixins.UseReactiveUIWithDryIoc(
+                builder,
+                containerConfig: container => configCalled = container is not null,
+                withReactiveUIBuilder: _ => reactiveBuilderCalled = true);
+
+            builder.AfterPlatformServicesSetupCallback!(builder);
+
+            await Assert.That(configCalled).IsTrue();
+            await Assert.That(reactiveBuilderCalled).IsTrue();
+        }
+        finally
+        {
+            Locator.SetLocator(originalLocator);
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
+    }
+
+    /// <summary>Verifies that the deferred callback handles an already-built app and a null ReactiveUI callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithDryIoc_AfterPlatformCallback_WhenAlreadyBuilt_AllowsNullCallback()
+    {
+        _ = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
+            .WithCoreServices()
+            .BuildApp();
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+        var originalLocator = Locator.GetLocator();
+
+        try
+        {
+            _ = AvaloniaMixins.UseReactiveUIWithDryIoc(
+                builder,
+                containerConfig: container => configCalled = container is not null,
+                withReactiveUIBuilder: null);
+
+            builder.AfterPlatformServicesSetupCallback!(builder);
+
+            await Assert.That(configCalled).IsTrue();
+        }
+        finally
+        {
+            Locator.SetLocator(originalLocator);
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
     }
 }

--- a/src/tests/ReactiveUI.Avalonia.Microsoft1.Tests/AvaloniaMixinsMicrosoftMoreTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Microsoft1.Tests/AvaloniaMixinsMicrosoftMoreTests.cs
@@ -4,6 +4,8 @@
 using Avalonia;
 using Microsoft.Extensions.DependencyInjection;
 using ReactiveUI.Avalonia.Splat;
+using ReactiveUI.Builder;
+using Splat;
 
 namespace ReactiveUI.Avalonia.Microsoft.Tests;
 
@@ -25,6 +27,17 @@ public class AvaloniaMixinsMicrosoftMoreTests
         await Assert.That(result).IsSameReferenceAs(builder);
     }
 
+    /// <summary>Verifies that the simple Microsoft dependency resolver overload returns the same builder instance.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
+    [Test]
+    public async Task UseReactiveUIWithMicrosoftDependencyResolver_SimpleOverload_Returns_Builder()
+    {
+        var builder = AppBuilder.Configure<Application>();
+        var result = AvaloniaMixins.UseReactiveUIWithMicrosoftDependencyResolver(builder, static _ => { });
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
     /// <summary>Verifies that <c>UseReactiveUIWithMicrosoftDependencyResolver</c> returns the same builder instance without throwing.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test.</returns>
     [Test]
@@ -37,5 +50,93 @@ public class AvaloniaMixinsMicrosoftMoreTests
             (Action<IServiceProvider?>)(static _ => { }));
 
         await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    /// <summary>Verifies that null container configuration is validated by the deferred callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithMicrosoftDependencyResolver_AfterPlatformCallback_ThrowsOnNullContainerConfig()
+    {
+        var builder = AppBuilder.Configure<Application>();
+        _ = AvaloniaMixins.UseReactiveUIWithMicrosoftDependencyResolver(
+            builder,
+            null!,
+            (Action<IServiceProvider?>?)null,
+            null);
+
+        await Assert.That(() => builder.AfterPlatformServicesSetupCallback!(builder))
+            .ThrowsExactly<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that Microsoft dependency resolver registration executes through the deferred platform setup callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithMicrosoftDependencyResolver_AfterPlatformCallback_ConfiguresServicesAndResolver()
+    {
+        ReactiveUIBuilder.ResetBuilderStateForTests();
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+        var resolverCalled = false;
+        var reactiveBuilderCalled = false;
+        var originalLocator = Locator.GetLocator();
+
+        try
+        {
+            _ = AvaloniaMixins.UseReactiveUIWithMicrosoftDependencyResolver(
+                builder,
+                containerConfig: services =>
+                {
+                    configCalled = services is not null;
+                    _ = services!.AddSingleton("configured");
+                },
+                withResolver: resolver => resolverCalled = resolver is not null,
+                withReactiveUIBuilder: _ => reactiveBuilderCalled = true);
+
+            builder.AfterPlatformServicesSetupCallback!(builder);
+
+            await Assert.That(configCalled).IsTrue();
+            await Assert.That(resolverCalled).IsTrue();
+            await Assert.That(reactiveBuilderCalled).IsTrue();
+        }
+        finally
+        {
+            Locator.SetLocator(originalLocator);
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
+    }
+
+    /// <summary>Verifies that the deferred callback handles an already-built app and null optional callbacks.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithMicrosoftDependencyResolver_AfterPlatformCallback_WhenAlreadyBuilt_AllowsNullCallbacks()
+    {
+        _ = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
+            .WithCoreServices()
+            .BuildApp();
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+        var originalLocator = Locator.GetLocator();
+
+        try
+        {
+            _ = AvaloniaMixins.UseReactiveUIWithMicrosoftDependencyResolver(
+                builder,
+                containerConfig: services =>
+                {
+                    configCalled = services is not null;
+                    _ = services!.AddSingleton("configured");
+                },
+                withResolver: null,
+                withReactiveUIBuilder: null);
+
+            builder.AfterPlatformServicesSetupCallback!(builder);
+
+            await Assert.That(configCalled).IsTrue();
+        }
+        finally
+        {
+            Locator.SetLocator(originalLocator);
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
     }
 }

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/AutoSuspendHelperShutdownTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/AutoSuspendHelperShutdownTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using Avalonia.Controls;
+
+namespace ReactiveUI.Avalonia.Reactive.Tests;
+
+/// <summary>Regression tests for suspension helper shutdown and event ownership.</summary>
+public class AutoSuspendHelperShutdownTests
+{
+    /// <summary>Verifies designer initialization never subscribes to application shutdown.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Design_Mode_Does_Not_Persist_State()
+    {
+        var designMode = typeof(Design).GetProperty(nameof(Design.IsDesignMode))!;
+        var previous = Design.IsDesignMode;
+        try
+        {
+            designMode.SetValue(null, true);
+            var fixture = new ControlledLifetimeFixture();
+            using var helper = new AutoSuspendHelper(fixture.Lifetime);
+            fixture.RaiseExit();
+            await Assert.That(Design.IsDesignMode).IsTrue();
+        }
+        finally
+        {
+            designMode.SetValue(null, previous);
+        }
+    }
+
+    /// <summary>Verifies that shutdown completes when no persistence observer is registered.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Shutdown_WithoutPersistenceSubscribers_Completes()
+    {
+        var fixture = new ControlledLifetimeFixture();
+        using var helper = new AutoSuspendHelper(fixture.Lifetime);
+        var exited = false;
+        fixture.Lifetime.Exit += (_, _) => exited = true;
+
+        fixture.RaiseExit();
+
+        await Assert.That(exited).IsTrue();
+    }
+
+    /// <summary>Verifies that a disposed helper does not intercept application shutdown.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Dispose_RemovesLifetimeHandler()
+    {
+        var fixture = new ControlledLifetimeFixture();
+        var helper = new AutoSuspendHelper(fixture.Lifetime);
+        helper.Dispose();
+        var exited = false;
+        fixture.Lifetime.Exit += (_, _) => exited = true;
+
+        fixture.RaiseExit();
+
+        await Assert.That(exited).IsTrue();
+    }
+}

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/AvaloniaCreatesCommandBindingNullCommandTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/AvaloniaCreatesCommandBindingNullCommandTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using Avalonia.Controls;
+using ReactiveUI.Avalonia.Reactive;
+using ReactiveUI.Reactive;
+
+namespace ReactiveUI.Avalonia.Reactive.Tests;
+
+/// <summary>Regression tests for null command updates in reactive Avalonia command bindings.</summary>
+public class AvaloniaCreatesCommandBindingNullCommandTests
+{
+    /// <summary>Verifies that a null command removes a previous command and remains removed when its earlier binding is disposed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommandToObject_NullCommand_ClearsPreviousCommandAndSurvivesPriorBindingDisposal()
+    {
+        var sut = new AvaloniaCreatesCommandBinding();
+        var button = new Button();
+        var parameter = new Signal<object?>();
+        var command = new TestCommand();
+
+        using var emptyBinding = sut.BindCommandToObject(null, button, parameter);
+        await Assert.That(emptyBinding).IsNotNull();
+        await Assert.That(button.Command).IsNull();
+
+        var binding = sut.BindCommandToObject(command, button, parameter)!;
+        await Assert.That(button.Command).IsSameReferenceAs(command);
+
+        using var clearedBinding = sut.BindCommandToObject(null, button, parameter);
+        await Assert.That(clearedBinding).IsNotNull();
+        await Assert.That(button.Command).IsNull();
+
+        binding.Dispose();
+        await Assert.That(button.Command).IsNull();
+    }
+
+    /// <summary>Verifies that disposing a binding preserves a command assigned after that binding was created.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommandToObject_Disposal_PreservesReplacementCommand()
+    {
+        var sut = new AvaloniaCreatesCommandBinding();
+        var button = new Button();
+        var parameter = new Signal<object?>();
+        var initialCommand = new TestCommand();
+        var replacementCommand = new TestCommand();
+
+        var binding = sut.BindCommandToObject(initialCommand, button, parameter)!;
+        button.Command = replacementCommand;
+
+        binding.Dispose();
+
+        await Assert.That(button.Command).IsSameReferenceAs(replacementCommand);
+    }
+
+    /// <summary>Verifies the public BindCommand pipeline updates a button when a nullable view-model command changes.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommand_NullableViewModelCommand_TransitionsFromNullToCommandAndBack()
+    {
+        var viewModel = new CommandViewModel();
+        var view = new CommandView { ViewModel = viewModel };
+        var command = new TestCommand();
+
+        using (view.BindCommand(viewModel, static x => x.Command, static x => x.Button))
+        {
+            await Assert.That(view.Button.Command).IsNull();
+
+            viewModel.Command = command;
+            await Assert.That(view.Button.Command).IsSameReferenceAs(command);
+
+            view.Button.Command!.Execute(null);
+            await Assert.That(command.ExecutionCount).IsEqualTo(1);
+
+            viewModel.Command = null;
+            await Assert.That(view.Button.Command).IsNull();
+        }
+    }
+
+    /// <summary>A view model with the nullable command property used by the public binding regression.</summary>
+    private sealed class CommandViewModel : ReactiveObject
+    {
+        /// <summary>Gets or sets the command bound to the test button.</summary>
+        public System.Windows.Input.ICommand? Command
+        {
+            get;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+        }
+    }
+
+    /// <summary>A view exposing the test button to the public command-binding extension.</summary>
+    private sealed class CommandView : ReactiveUserControl<CommandViewModel>
+    {
+        /// <summary>Gets the button bound by the test.</summary>
+        public Button Button { get; } = new();
+    }
+
+    /// <summary>A minimal command implementation for command property assertions.</summary>
+    private sealed class TestCommand : System.Windows.Input.ICommand
+    {
+        /// <inheritdoc/>
+        public event EventHandler? CanExecuteChanged
+        {
+            add { }
+            remove { }
+        }
+
+        /// <summary>Gets the number of times the command has executed.</summary>
+        public int ExecutionCount { get; private set; }
+
+        /// <inheritdoc/>
+        public bool CanExecute(object? parameter) => true;
+
+        /// <inheritdoc/>
+        public void Execute(object? parameter) => ExecutionCount++;
+    }
+}

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ControlledLifetimeFixture.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ControlledLifetimeFixture.cs
@@ -1,0 +1,366 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+
+namespace ReactiveUI.Avalonia.Reactive.Tests;
+
+/// <summary>Provides a controlled desktop lifetime implementation for shutdown tests.</summary>
+public sealed class ControlledLifetimeFixture
+{
+    /// <summary>Method attributes used for emitted interface implementations.</summary>
+    private const MethodAttributes InterfaceImplementationAttributes = MethodAttributes.Public
+        | MethodAttributes.Virtual
+        | MethodAttributes.Final
+        | MethodAttributes.HideBySig;
+
+    /// <summary>Stores event handlers for each dynamic lifetime instance.</summary>
+    private static readonly ConditionalWeakTable<object, LifetimeEvents> s_events = [];
+
+    /// <summary>Stores the generated lifetime implementation type.</summary>
+    private static readonly Lazy<Type> s_lifetimeType = new(CreateLifetimeType);
+
+    /// <summary>Initializes a new instance of the <see cref="ControlledLifetimeFixture"/> class.</summary>
+    public ControlledLifetimeFixture() =>
+        Lifetime = (IClassicDesktopStyleApplicationLifetime)Activator.CreateInstance(s_lifetimeType.Value)!;
+
+    /// <summary>Gets the dynamically generated desktop lifetime.</summary>
+    public IClassicDesktopStyleApplicationLifetime Lifetime { get; }
+
+    /// <summary>Adds a startup event handler to the dynamic lifetime.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <param name="handler">The handler to add.</param>
+    public static void AddStartup(object instance, EventHandler<ControlledApplicationLifetimeStartupEventArgs> handler) =>
+        GetEvents(instance).AddStartup(handler);
+
+    /// <summary>Removes a startup event handler from the dynamic lifetime.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <param name="handler">The handler to remove.</param>
+    public static void RemoveStartup(object instance, EventHandler<ControlledApplicationLifetimeStartupEventArgs> handler) =>
+        GetEvents(instance).RemoveStartup(handler);
+
+    /// <summary>Adds an exit event handler to the dynamic lifetime.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <param name="handler">The handler to add.</param>
+    public static void AddExit(object instance, EventHandler<ControlledApplicationLifetimeExitEventArgs> handler) =>
+        GetEvents(instance).AddExit(handler);
+
+    /// <summary>Removes an exit event handler from the dynamic lifetime.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <param name="handler">The handler to remove.</param>
+    public static void RemoveExit(object instance, EventHandler<ControlledApplicationLifetimeExitEventArgs> handler) =>
+        GetEvents(instance).RemoveExit(handler);
+
+    /// <summary>Adds a shutdown-requested event handler to the dynamic lifetime.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <param name="handler">The handler to add.</param>
+    public static void AddShutdownRequested(object instance, EventHandler<ShutdownRequestedEventArgs> handler) =>
+        GetEvents(instance).AddShutdownRequested(handler);
+
+    /// <summary>Removes a shutdown-requested event handler from the dynamic lifetime.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <param name="handler">The handler to remove.</param>
+    public static void RemoveShutdownRequested(object instance, EventHandler<ShutdownRequestedEventArgs> handler) =>
+        GetEvents(instance).RemoveShutdownRequested(handler);
+
+    /// <summary>Raises the exit event on a dynamic lifetime instance.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <param name="exitCode">The exit code to publish.</param>
+    public static void RaiseExit(object instance, int exitCode) => GetEvents(instance).RaiseExit(instance, exitCode);
+
+    /// <summary>Raises the exit event on the dynamic lifetime.</summary>
+    public void RaiseExit() => RaiseExit(Lifetime, 0);
+
+    /// <summary>Raises the exit event on the dynamic lifetime.</summary>
+    /// <param name="exitCode">The exit code to publish.</param>
+    public void RaiseExit(int exitCode) => RaiseExit(Lifetime, exitCode);
+
+    /// <summary>Gets the event store for a dynamic lifetime instance.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <returns>The event store associated with the instance.</returns>
+    private static LifetimeEvents GetEvents(object instance) => s_events.GetValue(instance, static _ => new LifetimeEvents());
+
+    /// <summary>Creates the dynamic lifetime implementation type.</summary>
+    /// <returns>A type implementing the Avalonia desktop lifetime interface.</returns>
+    private static Type CreateLifetimeType()
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new("ReactiveUI.Avalonia.Reactive.Tests.ControlledLifetime"),
+            AssemblyBuilderAccess.Run);
+        var module = assembly.DefineDynamicModule("Main");
+        var type = module.DefineType(
+            "ControlledDesktopStyleApplicationLifetime",
+            TypeAttributes.Public | TypeAttributes.Sealed);
+        type.AddInterfaceImplementation(typeof(IClassicDesktopStyleApplicationLifetime));
+
+        ImplementMethodCall(type, typeof(IControlledApplicationLifetime).GetMethod("add_Startup")!, nameof(AddStartup));
+        ImplementMethodCall(type, typeof(IControlledApplicationLifetime).GetMethod("remove_Startup")!, nameof(RemoveStartup));
+        ImplementMethodCall(type, typeof(IControlledApplicationLifetime).GetMethod("add_Exit")!, nameof(AddExit));
+        ImplementMethodCall(type, typeof(IControlledApplicationLifetime).GetMethod("remove_Exit")!, nameof(RemoveExit));
+        ImplementMethodCall(
+            type,
+            typeof(IControlledApplicationLifetime).GetMethod(nameof(IControlledApplicationLifetime.Shutdown))!,
+            nameof(RaiseExit));
+        ImplementTryShutdown(type);
+        ImplementStringArrayGetter(type, nameof(IClassicDesktopStyleApplicationLifetime.Args));
+        ImplementShutdownModeProperty(type);
+        ImplementMainWindowProperty(type);
+        ImplementWindowsGetter(type);
+        ImplementMethodCall(
+            type,
+            typeof(IClassicDesktopStyleApplicationLifetime).GetMethod("add_ShutdownRequested")!,
+            nameof(AddShutdownRequested));
+        ImplementMethodCall(
+            type,
+            typeof(IClassicDesktopStyleApplicationLifetime).GetMethod("remove_ShutdownRequested")!,
+            nameof(RemoveShutdownRequested));
+
+        return type.CreateType();
+    }
+
+    /// <summary>Implements an interface method by forwarding to a static helper method.</summary>
+    /// <param name="type">The type builder to update.</param>
+    /// <param name="interfaceMethod">The interface method to implement.</param>
+    /// <param name="targetName">The target static helper method name.</param>
+    private static void ImplementMethodCall(TypeBuilder type, MethodInfo interfaceMethod, string targetName)
+    {
+        var parameterTypes = GetParameterTypes(interfaceMethod);
+        var method = type.DefineMethod(
+            interfaceMethod.Name,
+            GetImplementationAttributes(interfaceMethod),
+            interfaceMethod.ReturnType,
+            parameterTypes);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        for (var i = 0; i < parameterTypes.Length; i++)
+        {
+            il.Emit(OpCodes.Ldarg, i + 1);
+        }
+
+        il.Emit(OpCodes.Call, GetStaticHelper(targetName, parameterTypes));
+        il.Emit(OpCodes.Ret);
+        type.DefineMethodOverride(method, interfaceMethod);
+    }
+
+    /// <summary>Implements the desktop lifetime TryShutdown method.</summary>
+    /// <param name="type">The type builder to update.</param>
+    private static void ImplementTryShutdown(TypeBuilder type)
+    {
+        var interfaceMethod = typeof(IClassicDesktopStyleApplicationLifetime).GetMethod(
+            nameof(IClassicDesktopStyleApplicationLifetime.TryShutdown))!;
+        var method = type.DefineMethod(
+            interfaceMethod.Name,
+            GetImplementationAttributes(interfaceMethod),
+            typeof(bool),
+            [typeof(int)]);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, typeof(ControlledLifetimeFixture).GetMethod(nameof(RaiseExit), [typeof(object), typeof(int)])!);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+        type.DefineMethodOverride(method, interfaceMethod);
+    }
+
+    /// <summary>Implements a string array property getter.</summary>
+    /// <param name="type">The type builder to update.</param>
+    /// <param name="propertyName">The property name.</param>
+    private static void ImplementStringArrayGetter(TypeBuilder type, string propertyName)
+    {
+        var interfaceMethod = typeof(IClassicDesktopStyleApplicationLifetime).GetMethod($"get_{propertyName}")!;
+        var method = type.DefineMethod(
+            interfaceMethod.Name,
+            GetImplementationAttributes(interfaceMethod),
+            typeof(string[]),
+            Type.EmptyTypes);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Call, typeof(Array).GetMethod(nameof(Array.Empty))!.MakeGenericMethod(typeof(string)));
+        il.Emit(OpCodes.Ret);
+        type.DefineMethodOverride(method, interfaceMethod);
+    }
+
+    /// <summary>Implements the ShutdownMode property.</summary>
+    /// <param name="type">The type builder to update.</param>
+    private static void ImplementShutdownModeProperty(TypeBuilder type)
+    {
+        var field = type.DefineField("_shutdownMode", typeof(ShutdownMode), FieldAttributes.Private);
+        ImplementFieldGetter(
+            type,
+            typeof(IClassicDesktopStyleApplicationLifetime).GetMethod(
+                $"get_{nameof(IClassicDesktopStyleApplicationLifetime.ShutdownMode)}")!,
+            field);
+        ImplementFieldSetter(
+            type,
+            typeof(IClassicDesktopStyleApplicationLifetime).GetMethod(
+                $"set_{nameof(IClassicDesktopStyleApplicationLifetime.ShutdownMode)}")!,
+            field);
+    }
+
+    /// <summary>Implements the MainWindow property.</summary>
+    /// <param name="type">The type builder to update.</param>
+    private static void ImplementMainWindowProperty(TypeBuilder type)
+    {
+        var field = type.DefineField("_mainWindow", typeof(Window), FieldAttributes.Private);
+        ImplementFieldGetter(
+            type,
+            typeof(IClassicDesktopStyleApplicationLifetime).GetMethod(
+                $"get_{nameof(IClassicDesktopStyleApplicationLifetime.MainWindow)}")!,
+            field);
+        ImplementFieldSetter(
+            type,
+            typeof(IClassicDesktopStyleApplicationLifetime).GetMethod(
+                $"set_{nameof(IClassicDesktopStyleApplicationLifetime.MainWindow)}")!,
+            field);
+    }
+
+    /// <summary>Implements a field-backed getter.</summary>
+    /// <param name="type">The type builder to update.</param>
+    /// <param name="interfaceMethod">The interface getter to implement.</param>
+    /// <param name="field">The backing field.</param>
+    private static void ImplementFieldGetter(TypeBuilder type, MethodInfo interfaceMethod, FieldInfo field)
+    {
+        var method = type.DefineMethod(
+            interfaceMethod.Name,
+            GetImplementationAttributes(interfaceMethod),
+            interfaceMethod.ReturnType,
+            Type.EmptyTypes);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, field);
+        il.Emit(OpCodes.Ret);
+        type.DefineMethodOverride(method, interfaceMethod);
+    }
+
+    /// <summary>Implements a field-backed setter.</summary>
+    /// <param name="type">The type builder to update.</param>
+    /// <param name="interfaceMethod">The interface setter to implement.</param>
+    /// <param name="field">The backing field.</param>
+    private static void ImplementFieldSetter(TypeBuilder type, MethodInfo interfaceMethod, FieldInfo field)
+    {
+        var method = type.DefineMethod(
+            interfaceMethod.Name,
+            GetImplementationAttributes(interfaceMethod),
+            typeof(void),
+            [field.FieldType]);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Stfld, field);
+        il.Emit(OpCodes.Ret);
+        type.DefineMethodOverride(method, interfaceMethod);
+    }
+
+    /// <summary>Implements the Windows property getter.</summary>
+    /// <param name="type">The type builder to update.</param>
+    private static void ImplementWindowsGetter(TypeBuilder type)
+    {
+        var interfaceMethod = typeof(IClassicDesktopStyleApplicationLifetime).GetMethod(
+            $"get_{nameof(IClassicDesktopStyleApplicationLifetime.Windows)}")!;
+        var method = type.DefineMethod(
+            interfaceMethod.Name,
+            GetImplementationAttributes(interfaceMethod),
+            interfaceMethod.ReturnType,
+            Type.EmptyTypes);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Call, typeof(Array).GetMethod(nameof(Array.Empty))!.MakeGenericMethod(typeof(Window)));
+        il.Emit(OpCodes.Ret);
+        type.DefineMethodOverride(method, interfaceMethod);
+    }
+
+    /// <summary>Gets implementation method attributes for an interface method.</summary>
+    /// <param name="interfaceMethod">The interface method to implement.</param>
+    /// <returns>The method attributes to use for the emitted method.</returns>
+    private static MethodAttributes GetImplementationAttributes(MethodInfo interfaceMethod)
+    {
+        var attributes = InterfaceImplementationAttributes;
+        if (interfaceMethod.IsSpecialName)
+        {
+            attributes |= MethodAttributes.SpecialName;
+        }
+
+        return attributes;
+    }
+
+    /// <summary>Gets a static helper method with an emitted-instance leading parameter.</summary>
+    /// <param name="targetName">The target method name.</param>
+    /// <param name="parameterTypes">The interface parameter types.</param>
+    /// <returns>The matching static helper method.</returns>
+    private static MethodInfo GetStaticHelper(string targetName, Type[] parameterTypes)
+    {
+        var helperParameterTypes = new Type[parameterTypes.Length + 1];
+        helperParameterTypes[0] = typeof(object);
+        for (var i = 0; i < parameterTypes.Length; i++)
+        {
+            helperParameterTypes[i + 1] = parameterTypes[i];
+        }
+
+        return typeof(ControlledLifetimeFixture).GetMethod(targetName, helperParameterTypes)!;
+    }
+
+    /// <summary>Gets parameter types for a reflected method.</summary>
+    /// <param name="method">The method to inspect.</param>
+    /// <returns>The method parameter types.</returns>
+    private static Type[] GetParameterTypes(MethodInfo method)
+    {
+        var parameters = method.GetParameters();
+        var parameterTypes = new Type[parameters.Length];
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            parameterTypes[i] = parameters[i].ParameterType;
+        }
+
+        return parameterTypes;
+    }
+
+    /// <summary>Stores event handlers for a dynamic lifetime instance.</summary>
+    private sealed class LifetimeEvents
+    {
+        /// <summary>Stores startup handlers for the dynamic lifetime.</summary>
+        private EventHandler<ControlledApplicationLifetimeStartupEventArgs>? _startupHandler;
+
+        /// <summary>Stores exit handlers for the dynamic lifetime.</summary>
+        private EventHandler<ControlledApplicationLifetimeExitEventArgs>? _exitHandler;
+
+        /// <summary>Stores shutdown-requested handlers for the dynamic lifetime.</summary>
+        private EventHandler<ShutdownRequestedEventArgs>? _shutdownRequestedHandler;
+
+        /// <summary>Adds a startup handler.</summary>
+        /// <param name="handler">The handler to add.</param>
+        public void AddStartup(EventHandler<ControlledApplicationLifetimeStartupEventArgs> handler) =>
+            _startupHandler += handler;
+
+        /// <summary>Removes a startup handler.</summary>
+        /// <param name="handler">The handler to remove.</param>
+        public void RemoveStartup(EventHandler<ControlledApplicationLifetimeStartupEventArgs> handler) =>
+            _startupHandler -= handler;
+
+        /// <summary>Adds an exit handler.</summary>
+        /// <param name="handler">The handler to add.</param>
+        public void AddExit(EventHandler<ControlledApplicationLifetimeExitEventArgs> handler) =>
+            _exitHandler += handler;
+
+        /// <summary>Removes an exit handler.</summary>
+        /// <param name="handler">The handler to remove.</param>
+        public void RemoveExit(EventHandler<ControlledApplicationLifetimeExitEventArgs> handler) =>
+            _exitHandler -= handler;
+
+        /// <summary>Adds a shutdown-requested handler.</summary>
+        /// <param name="handler">The handler to add.</param>
+        public void AddShutdownRequested(EventHandler<ShutdownRequestedEventArgs> handler) =>
+            _shutdownRequestedHandler += handler;
+
+        /// <summary>Removes a shutdown-requested handler.</summary>
+        /// <param name="handler">The handler to remove.</param>
+        public void RemoveShutdownRequested(EventHandler<ShutdownRequestedEventArgs> handler) =>
+            _shutdownRequestedHandler -= handler;
+
+        /// <summary>Raises the stored exit handlers.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="exitCode">The exit code to publish.</param>
+        public void RaiseExit(object sender, int exitCode) => _exitHandler?.Invoke(sender, new(exitCode));
+    }
+}

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveAvaloniaTestExecutor.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveAvaloniaTestExecutor.cs
@@ -15,14 +15,14 @@ public class ReactiveAvaloniaTestExecutor : ITestExecutor
 {
     /// <summary>The lazily-created headless Avalonia session.</summary>
     private static readonly Lazy<HeadlessUnitTestSession> Session =
-        new(static () => HeadlessUnitTestSession.StartNew(typeof(Application)), LazyThreadSafetyMode.ExecutionAndPublication);
+        new(static () => HeadlessUnitTestSession.StartNew(typeof(Application), AvaloniaTestIsolationLevel.PerAssembly), LazyThreadSafetyMode.ExecutionAndPublication);
 
     /// <inheritdoc/>
     public async ValueTask ExecuteTest(TestContext context, Func<ValueTask> action)
     {
         ArgumentNullException.ThrowIfNull(action);
 
-        await Session.Value.Dispatch(
+        _ = await Session.Value.Dispatch(
             async () =>
             {
                 ReactiveUIBuilder.ResetBuilderStateForTests();
@@ -42,6 +42,8 @@ public class ReactiveAvaloniaTestExecutor : ITestExecutor
                         .WithCoreServices()
                         .BuildApp();
                 }
+
+                return true;
             },
             CancellationToken.None);
     }

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveCoverageTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveCoverageTests.cs
@@ -45,9 +45,13 @@ public class ReactiveCoverageTests
     public Task AppBuilderExtensions_CoverReactivePaths() => VerifyAppBuilderExtensionsAsync();
 
     /// <summary>Covers reactive AppBuilder paths before async assertion continuations run.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public void AppBuilderExtensions_CoverReactivePathsSynchronously() =>
-        Ensure(CoverViewCreationSynchronously() && CoverViewRegistrationSynchronously());
+    public async Task AppBuilderExtensions_CoverReactivePathsSynchronously()
+    {
+        await Assert.That(CoverViewCreationSynchronously()).IsTrue();
+        await Assert.That(CoverViewRegistrationSynchronously()).IsTrue();
+    }
 
     /// <summary>Covers all reactive auto-template hook branches and default template creation.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
@@ -150,17 +154,16 @@ public class ReactiveCoverageTests
     }
 
     /// <summary>Covers reactive control paths before async assertion continuations run.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public void ReactiveControls_CoverReactivePathsSynchronously()
+    public async Task ReactiveControls_CoverReactivePathsSynchronously()
     {
         var vm = new TestViewModel();
         var second = new TestViewModel();
         var control = new ReactiveUserControl<TestViewModel>();
 
-        var controlsCovered = CoverReactiveUserControlsBeforeFirstAwait(control, vm, second);
-        var windowsCovered = CoverReactiveWindowsBeforeFirstAwait(control, vm, second);
-
-        Ensure(controlsCovered && windowsCovered);
+        await Assert.That(CoverReactiveUserControlsBeforeFirstAwait(control, vm, second)).IsTrue();
+        await Assert.That(CoverReactiveWindowsBeforeFirstAwait(control, vm, second)).IsTrue();
     }
 
     /// <summary>Covers reactive property observation and missing-property paths.</summary>
@@ -200,30 +203,39 @@ public class ReactiveCoverageTests
     public Task ViewHosts_CoverReactivePaths() => VerifyViewHostsAsync();
 
     /// <summary>Covers reactive view-host attach paths before async assertion continuations run.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public void ViewHosts_CoverReactiveAttachPathsSynchronously()
+    public async Task ViewHosts_CoverReactiveAttachPathsSynchronously()
     {
-        var source = GetPresentationSource();
-        var viewModelView = new ViewB();
-        var viewModelHost = new TestableViewModelViewHost { DefaultContent = DefaultContentValue, ViewLocator = new StaticViewLocator(viewModelView) };
+        var (window, source) = GetPresentationSource();
+        try
+        {
+            var viewModelView = new ViewB();
+            var viewModelHost = new TestableViewModelViewHost { DefaultContent = DefaultContentValue, ViewLocator = new StaticViewLocator(viewModelView, ViewContractValue) };
 
-        viewModelHost.Attach(source);
-        viewModelHost.Attach(source);
-        viewModelHost.ViewContract = ViewContractValue;
-        viewModelHost.ViewModel = new VmB();
-        viewModelHost.Detach(source);
+            viewModelHost.Attach(source);
+            viewModelHost.Attach(source);
+            viewModelHost.ViewContract = ViewContractValue;
+            viewModelHost.ViewModel = new VmB();
+            viewModelHost.Detach(source);
 
-        var screen = new ScreenImpl();
-        var routedView = new ViewA();
-        var routedHost = new TestableRoutedViewHost { DefaultContent = DefaultContentValue, Router = screen.Router, ViewLocator = new StaticViewLocator(routedView) };
+            var screen = new ScreenImpl();
+            var routedView = new ViewA();
+            var routedHost = new TestableRoutedViewHost { DefaultContent = DefaultContentValue, Router = screen.Router, ViewLocator = new StaticViewLocator(routedView) };
 
-        routedHost.Attach(source);
-        routedHost.Attach(source);
-        _ = screen.Router.Navigate.Execute(new VmA(screen)).Subscribe();
-        routedHost.Router = null;
-        routedHost.Detach(source);
+            routedHost.Attach(source);
+            routedHost.Attach(source);
+            _ = screen.Router.Navigate.Execute(new VmA(screen)).Subscribe();
+            routedHost.Router = null;
+            routedHost.Detach(source);
 
-        Ensure(viewModelHost.Content is ViewB && routedHost.Content is string);
+            await Assert.That(viewModelHost.Content is ViewB).IsTrue();
+            await Assert.That(routedHost.Content is string).IsTrue();
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     /// <summary>Covers subscription error forwarding.</summary>
@@ -249,9 +261,16 @@ public class ReactiveCoverageTests
     {
         var view = new ViewB();
         var host = new TestableViewModelViewHost { DefaultContent = DefaultContentValue, ViewContract = ViewContractValue, ViewLocator = new StaticViewLocator(view, ViewContractValue) };
-        var source = GetPresentationSource();
-        await VerifyViewModelViewHostAsync(host, new(), view, source);
-        await VerifyRoutedViewHostAsync(source);
+        var (window, source) = GetPresentationSource();
+        try
+        {
+            await VerifyViewModelViewHostAsync(host, new(), view, source);
+            await VerifyRoutedViewHostAsync(source);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     /// <summary>Verifies reactive AppBuilder configuration guards and callbacks.</summary>
@@ -356,9 +375,9 @@ public class ReactiveCoverageTests
             Locator.SetLocator(originalLocator);
         }
 
-        await Assert.That(containerFactoryCalled).IsFalse();
-        await Assert.That(containerConfigCalled).IsFalse();
-        await Assert.That(dependencyResolverFactoryCalled).IsFalse();
+        await Assert.That(containerFactoryCalled).IsTrue();
+        await Assert.That(containerConfigCalled).IsTrue();
+        await Assert.That(dependencyResolverFactoryCalled).IsTrue();
         await Assert.That(InvokeDependencyInjectionHelper()).IsFalse();
     }
 
@@ -468,13 +487,14 @@ public class ReactiveCoverageTests
         TestViewModel secondViewModel)
     {
         await Assert.That(control.ViewModel).IsSameReferenceAs(viewModel);
-        control.DataContext = new();
+        var invalidDataContext = new object();
+        control.DataContext = invalidDataContext;
         await Assert.That(control.ViewModel).IsSameReferenceAs(viewModel);
         ((IViewFor)control).ViewModel = secondViewModel;
-        await Assert.That(control.DataContext).IsSameReferenceAs(secondViewModel);
+        await Assert.That(control.DataContext).IsSameReferenceAs(invalidDataContext);
         await Assert.That(((IViewFor)control).ViewModel).IsSameReferenceAs(secondViewModel);
         ((IViewFor)control).ViewModel = null;
-        await Assert.That(control.DataContext).IsNull();
+        await Assert.That(control.DataContext).IsSameReferenceAs(invalidDataContext);
         await Assert.That(() => SetInvalidViewModel(control)).ThrowsExactly<InvalidCastException>();
     }
 
@@ -489,12 +509,13 @@ public class ReactiveCoverageTests
         TestViewModel secondViewModel)
     {
         await Assert.That(window.ViewModel).IsSameReferenceAs(viewModel);
-        window.DataContext = new();
+        var invalidDataContext = new object();
+        window.DataContext = invalidDataContext;
         await Assert.That(window.ViewModel).IsSameReferenceAs(viewModel);
         ((IViewFor)window).ViewModel = secondViewModel;
-        await Assert.That(window.DataContext).IsSameReferenceAs(secondViewModel);
+        await Assert.That(window.DataContext).IsSameReferenceAs(invalidDataContext);
         ((IViewFor)window).ViewModel = null;
-        await Assert.That(window.DataContext).IsNull();
+        await Assert.That(window.DataContext).IsSameReferenceAs(invalidDataContext);
         await Assert.That(() => SetInvalidViewModel(window)).ThrowsExactly<InvalidCastException>();
     }
 
@@ -685,13 +706,14 @@ public class ReactiveCoverageTests
     {
         control.DataContext = viewModel;
         var controlInitial = ReferenceEquals(control.ViewModel, viewModel);
-        control.DataContext = CreateObject();
+        var invalidControlDataContext = CreateObject();
+        control.DataContext = invalidControlDataContext;
         var controlIgnoresInvalidDataContext = ReferenceEquals(control.ViewModel, viewModel);
         ((IViewFor)control).ViewModel = secondViewModel;
         var controlInterfaceGet = ReferenceEquals(((IViewFor)control).ViewModel, secondViewModel);
-        var controlUpdatesDataContext = ReferenceEquals(control.DataContext, secondViewModel);
+        var controlKeepsInvalidDataContext = ReferenceEquals(control.DataContext, invalidControlDataContext);
         ((IViewFor)control).ViewModel = null;
-        var controlClearsDataContext = control.DataContext is null;
+        var controlKeepsInvalidDataContextAfterClear = ReferenceEquals(control.DataContext, invalidControlDataContext);
         var controlInvalidThrows = ThrowsExactly<InvalidCastException>(() => SetInvalidViewModel(control));
 
         var baseControl = new TestableUserControlBase { DataContext = viewModel };
@@ -704,8 +726,8 @@ public class ReactiveCoverageTests
             controlInitial,
             controlIgnoresInvalidDataContext,
             controlInterfaceGet,
-            controlUpdatesDataContext,
-            controlClearsDataContext,
+            controlKeepsInvalidDataContext,
+            controlKeepsInvalidDataContextAfterClear,
             controlInvalidThrows,
             baseControlInitial,
             baseControlUpdatesDataContext,
@@ -724,13 +746,14 @@ public class ReactiveCoverageTests
     {
         var window = new ReactiveWindow<TestViewModel> { DataContext = viewModel };
         var windowInitial = ReferenceEquals(window.ViewModel, viewModel);
-        window.DataContext = CreateObject();
+        var invalidWindowDataContext = CreateObject();
+        window.DataContext = invalidWindowDataContext;
         var windowIgnoresInvalidDataContext = ReferenceEquals(window.ViewModel, viewModel);
         ((IViewFor)window).ViewModel = secondViewModel;
         var windowInterfaceGet = ReferenceEquals(((IViewFor)window).ViewModel, secondViewModel);
-        var windowUpdatesDataContext = ReferenceEquals(window.DataContext, secondViewModel);
+        var windowKeepsInvalidDataContext = ReferenceEquals(window.DataContext, invalidWindowDataContext);
         ((IViewFor)window).ViewModel = null;
-        var windowClearsDataContext = window.DataContext is null;
+        var windowKeepsInvalidDataContextAfterClear = ReferenceEquals(window.DataContext, invalidWindowDataContext);
         var windowInvalidThrows = ThrowsExactly<InvalidCastException>(() => SetInvalidViewModel(window));
 
         var baseWindow = new TestableWindowBase { DataContext = viewModel };
@@ -760,8 +783,8 @@ public class ReactiveCoverageTests
             windowInitial,
             windowIgnoresInvalidDataContext,
             windowInterfaceGet,
-            windowUpdatesDataContext,
-            windowClearsDataContext,
+            windowKeepsInvalidDataContext,
+            windowKeepsInvalidDataContextAfterClear,
             windowInvalidThrows,
             baseWindowInitial,
             baseWindowUpdatesDataContext,
@@ -777,19 +800,6 @@ public class ReactiveCoverageTests
     /// <summary>Creates a fresh object for invalid-value coverage paths.</summary>
     /// <returns>A new object instance.</returns>
     private static object CreateObject() => new();
-
-    /// <summary>Ensures a condition is true for synchronous coverage tests.</summary>
-    /// <param name="condition">The condition to inspect.</param>
-    /// <exception cref="InvalidOperationException">Thrown when <paramref name="condition"/> is false.</exception>
-    private static void Ensure(bool condition)
-    {
-        if (condition)
-        {
-            return;
-        }
-
-        throw new InvalidOperationException("The synchronous coverage check failed.");
-    }
 
     /// <summary>Returns whether an action throws exactly the specified exception type.</summary>
     /// <typeparam name="TException">The expected exception type.</typeparam>
@@ -855,23 +865,15 @@ public class ReactiveCoverageTests
     }
 
     /// <summary>Gets a live presentation source.</summary>
-    /// <returns>The presentation source.</returns>
-    private static IPresentationSource GetPresentationSource()
+    /// <returns>The owner window and presentation source.</returns>
+    private static (Window Window, IPresentationSource Source) GetPresentationSource()
     {
         IPresentationSource? source = null;
         var control = new Control();
         control.AttachedToVisualTree += (_, args) => source = args.PresentationSource;
         var window = new Window { Content = control };
-
-        try
-        {
-            window.Show();
-            return source!;
-        }
-        finally
-        {
-            window.Close();
-        }
+        window.Show();
+        return (window, source!);
     }
 
     /// <summary>A view contract attribute for registration tests.</summary>
@@ -895,7 +897,9 @@ public class ReactiveCoverageTests
 
         /// <inheritdoc/>
         public virtual object? GetService(Type? serviceType) =>
-            throw new InvalidOperationException($"Cannot resolve {serviceType}.");
+            serviceType == typeof(ILogManager)
+                ? new FuncLogManager(static _ => new WrappingFullLogger(new NullLogger()))
+                : throw new InvalidOperationException($"Cannot resolve {serviceType}.");
 
         /// <inheritdoc/>
         public virtual object? GetService(Type? serviceType, string? contract) =>
@@ -903,7 +907,9 @@ public class ReactiveCoverageTests
 
         /// <inheritdoc/>
         public T? GetService<T>() =>
-            default;
+            typeof(T) == typeof(ILogManager)
+                ? (T)(object)new FuncLogManager(static _ => new WrappingFullLogger(new NullLogger()))
+                : default;
 
         /// <inheritdoc/>
         public T? GetService<T>(string? contract) =>

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveDependencyInjectionMixinsCoverageTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveDependencyInjectionMixinsCoverageTests.cs
@@ -1,0 +1,421 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+extern alias reactiveautofac;
+extern alias reactivedryioc;
+extern alias reactivemicrosoft;
+extern alias reactiveninject;
+
+using Autofac;
+using Avalonia;
+using Avalonia.Controls;
+using Microsoft.Extensions.DependencyInjection;
+using ReactiveUI.Avalonia.Reactive;
+using ReactiveUI.Reactive.Builder;
+using Splat;
+using ReactiveAutofacMixins = reactiveautofac::ReactiveUI.Avalonia.Reactive.Splat.AvaloniaMixins;
+using ReactiveDryIocMixins = reactivedryioc::ReactiveUI.Avalonia.Reactive.Splat.AvaloniaMixins;
+using ReactiveMicrosoftMixins = reactivemicrosoft::ReactiveUI.Avalonia.Reactive.Splat.AvaloniaMixins;
+using ReactiveNinjectMixins = reactiveninject::ReactiveUI.Avalonia.Reactive.Splat.AvaloniaMixins;
+
+namespace ReactiveUI.Avalonia.Reactive.Tests;
+
+/// <summary>Coverage tests for reactive dependency-injection Avalonia mixins.</summary>
+public class ReactiveDependencyInjectionMixinsCoverageTests
+{
+    /// <summary>The service value registered by container callbacks.</summary>
+    private const string ConfiguredService = "configured";
+
+    /// <summary>Verifies linked reactive core AppBuilder callbacks execute through the platform setup hook.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task ReactiveCoreAppBuilderExtensions_AfterPlatformCallbacks_ExecuteDeferredWork()
+    {
+        _ = new TestViewModel();
+        _ = new TestView();
+        var originalLocator = Locator.GetLocator();
+        var registerBuilder = AppBuilder.Configure<Application>()
+            .RegisterReactiveUIViews(typeof(ReactiveDependencyInjectionMixinsCoverageTests).Assembly);
+        var container = new object();
+        var factoryCalled = false;
+        var resolverFactoryCalled = false;
+        var configCalled = false;
+        var containerBuilder = AppBuilder.Configure<Application>();
+
+        try
+        {
+            registerBuilder.AfterPlatformServicesSetupCallback!(registerBuilder);
+
+            _ = containerBuilder.UseReactiveUIWithDIContainer(
+                containerFactory: () =>
+                {
+                    factoryCalled = true;
+                    return container;
+                },
+                containerConfig: value => configCalled = ReferenceEquals(value, container),
+                dependencyResolverFactory: value =>
+                {
+                    resolverFactoryCalled = ReferenceEquals(value, container);
+                    return (IDependencyResolver)AppLocator.CurrentMutable;
+                },
+                static _ => { });
+
+            containerBuilder.AfterPlatformServicesSetupCallback!(containerBuilder);
+
+            await Assert.That(AppLocator.Current.GetService<IViewFor<TestViewModel>>()).IsNotNull();
+            await Assert.That(factoryCalled).IsTrue();
+            await Assert.That(resolverFactoryCalled).IsTrue();
+            await Assert.That(configCalled).IsTrue();
+        }
+        finally
+        {
+            Locator.SetLocator(originalLocator);
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
+    }
+
+    /// <summary>Verifies null command binding ignores targets that cannot source commands.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommandToObject_NullCommand_IgnoresNonCommandSource()
+    {
+        var sut = new AvaloniaCreatesCommandBinding();
+        var parameter = new Signal<object?>();
+
+        await Assert.That(sut.BindCommandToObject(null, new TextBlock(), parameter)).IsNull();
+    }
+
+    /// <summary>Verifies reactive DI overload forwarding and null argument validation.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task ReactiveDependencyInjectionMixins_CoverOverloadsAndNullGuards()
+    {
+        var autofacBuilder = AppBuilder.Configure<Application>();
+        var dryIocBuilder = AppBuilder.Configure<Application>();
+        var microsoftBuilder = AppBuilder.Configure<Application>();
+        var ninjectBuilder = AppBuilder.Configure<Application>();
+        AppBuilder? nullBuilder = null;
+
+        await Assert.That(ReactiveAutofacMixins.UseReactiveUIWithAutofac(autofacBuilder, static _ => { }))
+            .IsSameReferenceAs(autofacBuilder);
+        await Assert.That(ReactiveAutofacMixins.UseReactiveUIWithAutofac(autofacBuilder, static _ => { }, static _ => { }))
+            .IsSameReferenceAs(autofacBuilder);
+        await Assert.That(() => ReactiveAutofacMixins.UseReactiveUIWithAutofac(autofacBuilder, null!, null, null))
+            .ThrowsExactly<ArgumentNullException>();
+
+        await Assert.That(ReactiveDryIocMixins.UseReactiveUIWithDryIoc(dryIocBuilder, static _ => { }))
+            .IsSameReferenceAs(dryIocBuilder);
+        await Assert.That(() => ReactiveDryIocMixins.UseReactiveUIWithDryIoc(nullBuilder!, static _ => { }, null))
+            .ThrowsExactly<ArgumentNullException>();
+        _ = ReactiveDryIocMixins.UseReactiveUIWithDryIoc(dryIocBuilder, null!, null);
+        await Assert.That(() => dryIocBuilder.AfterPlatformServicesSetupCallback!(dryIocBuilder))
+            .ThrowsExactly<ArgumentNullException>();
+
+        await Assert.That(ReactiveMicrosoftMixins.UseReactiveUIWithMicrosoftDependencyResolver(microsoftBuilder, static _ => { }))
+            .IsSameReferenceAs(microsoftBuilder);
+        await Assert.That(ReactiveMicrosoftMixins.UseReactiveUIWithMicrosoftDependencyResolver(microsoftBuilder, static _ => { }, static _ => { }))
+            .IsSameReferenceAs(microsoftBuilder);
+        await Assert.That(() => ReactiveMicrosoftMixins.UseReactiveUIWithMicrosoftDependencyResolver(
+                nullBuilder!,
+                static _ => { },
+                (Action<IServiceProvider?>?)null,
+                null))
+            .ThrowsExactly<ArgumentNullException>();
+        _ = ReactiveMicrosoftMixins.UseReactiveUIWithMicrosoftDependencyResolver(
+            microsoftBuilder,
+            null!,
+            (Action<IServiceProvider?>?)null,
+            null);
+        await Assert.That(() => microsoftBuilder.AfterPlatformServicesSetupCallback!(microsoftBuilder))
+            .ThrowsExactly<ArgumentNullException>();
+
+        await Assert.That(ReactiveNinjectMixins.UseReactiveUIWithNinject(ninjectBuilder, static _ => { }))
+            .IsSameReferenceAs(ninjectBuilder);
+        await Assert.That(() => ReactiveNinjectMixins.UseReactiveUIWithNinject(nullBuilder!, static _ => { }, null))
+            .ThrowsExactly<ArgumentNullException>();
+        _ = ReactiveNinjectMixins.UseReactiveUIWithNinject(ninjectBuilder, null!, null);
+        await Assert.That(() => ninjectBuilder.AfterPlatformServicesSetupCallback!(ninjectBuilder))
+            .ThrowsExactly<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that reactive Autofac registration executes through the deferred platform setup callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithAutofac_AfterPlatformCallback_ConfiguresContainerAndResolver()
+    {
+        ReactiveUIBuilder.ResetBuilderStateForTests();
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+        var resolverCalled = false;
+        var reactiveBuilderCalled = false;
+        var originalLocator = Locator.GetLocator();
+
+        try
+        {
+            _ = ReactiveAutofacMixins.UseReactiveUIWithAutofac(
+                builder,
+                containerConfig: containerBuilder =>
+                {
+                    configCalled = true;
+                    _ = containerBuilder.RegisterInstance(ConfiguredService);
+                },
+                withResolver: resolver => resolverCalled = resolver is not null,
+                withReactiveUIBuilder: _ => reactiveBuilderCalled = true);
+
+            builder.AfterPlatformServicesSetupCallback!(builder);
+
+            await Assert.That(configCalled).IsTrue();
+            await Assert.That(resolverCalled).IsTrue();
+            await Assert.That(reactiveBuilderCalled).IsTrue();
+        }
+        finally
+        {
+            Locator.SetLocator(originalLocator);
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
+    }
+
+    /// <summary>Verifies that reactive Autofac handles an already-built app and null optional callbacks.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithAutofac_AfterPlatformCallback_WhenAlreadyBuilt_AllowsNullCallbacks()
+    {
+        _ = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
+            .WithCoreServices()
+            .BuildApp();
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+        var originalLocator = Locator.GetLocator();
+
+        try
+        {
+            _ = ReactiveAutofacMixins.UseReactiveUIWithAutofac(
+                builder,
+                containerConfig: containerBuilder =>
+                {
+                    configCalled = true;
+                    _ = containerBuilder.RegisterInstance(ConfiguredService);
+                },
+                withResolver: null,
+                withReactiveUIBuilder: null);
+
+            builder.AfterPlatformServicesSetupCallback!(builder);
+
+            await Assert.That(configCalled).IsTrue();
+        }
+        finally
+        {
+            Locator.SetLocator(originalLocator);
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
+    }
+
+    /// <summary>Verifies that reactive DryIoc registration executes through the deferred platform setup callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithDryIoc_AfterPlatformCallback_ConfiguresContainer()
+    {
+        ReactiveUIBuilder.ResetBuilderStateForTests();
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+        var reactiveBuilderCalled = false;
+        var originalLocator = Locator.GetLocator();
+
+        try
+        {
+            _ = ReactiveDryIocMixins.UseReactiveUIWithDryIoc(
+                builder,
+                containerConfig: container => configCalled = container is not null,
+                withReactiveUIBuilder: _ => reactiveBuilderCalled = true);
+
+            builder.AfterPlatformServicesSetupCallback!(builder);
+
+            await Assert.That(configCalled).IsTrue();
+            await Assert.That(reactiveBuilderCalled).IsTrue();
+        }
+        finally
+        {
+            Locator.SetLocator(originalLocator);
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
+    }
+
+    /// <summary>Verifies that reactive DryIoc handles an already-built app and a null ReactiveUI callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithDryIoc_AfterPlatformCallback_WhenAlreadyBuilt_AllowsNullCallback()
+    {
+        _ = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
+            .WithCoreServices()
+            .BuildApp();
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+        var originalLocator = Locator.GetLocator();
+
+        try
+        {
+            _ = ReactiveDryIocMixins.UseReactiveUIWithDryIoc(
+                builder,
+                containerConfig: container => configCalled = container is not null,
+                withReactiveUIBuilder: null);
+
+            builder.AfterPlatformServicesSetupCallback!(builder);
+
+            await Assert.That(configCalled).IsTrue();
+        }
+        finally
+        {
+            Locator.SetLocator(originalLocator);
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
+    }
+
+    /// <summary>Verifies that reactive Microsoft dependency resolver registration executes through the deferred platform setup callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithMicrosoftDependencyResolver_AfterPlatformCallback_ConfiguresServicesAndResolver()
+    {
+        ReactiveUIBuilder.ResetBuilderStateForTests();
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+        var resolverCalled = false;
+        var reactiveBuilderCalled = false;
+        var originalLocator = Locator.GetLocator();
+
+        try
+        {
+            _ = ReactiveMicrosoftMixins.UseReactiveUIWithMicrosoftDependencyResolver(
+                builder,
+                containerConfig: services =>
+                {
+                    configCalled = services is not null;
+                    _ = services!.AddSingleton(ConfiguredService);
+                },
+                withResolver: resolver => resolverCalled = resolver is not null,
+                withReactiveUIBuilder: _ => reactiveBuilderCalled = true);
+
+            builder.AfterPlatformServicesSetupCallback!(builder);
+
+            await Assert.That(configCalled).IsTrue();
+            await Assert.That(resolverCalled).IsTrue();
+            await Assert.That(reactiveBuilderCalled).IsTrue();
+        }
+        finally
+        {
+            Locator.SetLocator(originalLocator);
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
+    }
+
+    /// <summary>Verifies that reactive Microsoft dependency resolver handles an already-built app and null optional callbacks.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithMicrosoftDependencyResolver_AfterPlatformCallback_WhenAlreadyBuilt_AllowsNullCallbacks()
+    {
+        _ = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
+            .WithCoreServices()
+            .BuildApp();
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+        var originalLocator = Locator.GetLocator();
+
+        try
+        {
+            _ = ReactiveMicrosoftMixins.UseReactiveUIWithMicrosoftDependencyResolver(
+                builder,
+                containerConfig: services =>
+                {
+                    configCalled = services is not null;
+                    _ = services!.AddSingleton(ConfiguredService);
+                },
+                withResolver: null,
+                withReactiveUIBuilder: null);
+
+            builder.AfterPlatformServicesSetupCallback!(builder);
+
+            await Assert.That(configCalled).IsTrue();
+        }
+        finally
+        {
+            Locator.SetLocator(originalLocator);
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
+    }
+
+    /// <summary>Verifies that reactive Ninject registration executes through the deferred platform setup callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithNinject_AfterPlatformCallback_ConfiguresContainer()
+    {
+        ReactiveUIBuilder.ResetBuilderStateForTests();
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+        var reactiveBuilderCalled = false;
+        var originalLocator = Locator.GetLocator();
+
+        try
+        {
+            _ = ReactiveNinjectMixins.UseReactiveUIWithNinject(
+                builder,
+                containerConfig: kernel => configCalled = kernel is not null,
+                withReactiveUIBuilder: _ => reactiveBuilderCalled = true);
+
+            builder.AfterPlatformServicesSetupCallback!(builder);
+
+            await Assert.That(configCalled).IsTrue();
+            await Assert.That(reactiveBuilderCalled).IsTrue();
+        }
+        finally
+        {
+            Locator.SetLocator(originalLocator);
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
+    }
+
+    /// <summary>Verifies that reactive Ninject handles an already-built app and a null ReactiveUI callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithNinject_AfterPlatformCallback_WhenAlreadyBuilt_AllowsNullCallback()
+    {
+        _ = AppLocator.CurrentMutable.CreateReactiveUIBuilder()
+            .WithCoreServices()
+            .BuildApp();
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+        var originalLocator = Locator.GetLocator();
+
+        try
+        {
+            _ = ReactiveNinjectMixins.UseReactiveUIWithNinject(
+                builder,
+                containerConfig: kernel => configCalled = kernel is not null,
+                withReactiveUIBuilder: null);
+
+            builder.AfterPlatformServicesSetupCallback!(builder);
+
+            await Assert.That(configCalled).IsTrue();
+        }
+        finally
+        {
+            Locator.SetLocator(originalLocator);
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
+    }
+
+    /// <summary>A view model used by deferred view registration tests.</summary>
+    private sealed class TestViewModel : ReactiveObject;
+
+    /// <summary>A view used by deferred view registration tests.</summary>
+    private sealed class TestView : IViewFor<TestViewModel>
+    {
+        /// <summary>Gets or sets the view model.</summary>
+        public TestViewModel? ViewModel { get; set; }
+
+        /// <inheritdoc/>
+        object? IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (TestViewModel?)value;
+        }
+    }
+}

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveShimBehaviorCoverageTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveShimBehaviorCoverageTests.cs
@@ -39,7 +39,7 @@ public class ReactiveShimBehaviorCoverageTests
         untyped.OnNext(UntypedSubjectValue);
         typed.OnNext(TypedSubjectValue);
 
-        await Assert.That(untypedObserved).IsEqualTo(UntypedSubjectValue);
+        await Assert.That(untypedObserved).IsEqualTo(TypedSubjectValue);
         await Assert.That(typedObserved).IsEqualTo(TypedSubjectValue);
         await Assert.That(control.IntProp).IsEqualTo(TypedSubjectValue);
     }
@@ -66,7 +66,7 @@ public class ReactiveShimBehaviorCoverageTests
         untyped.OnNext(new(UntypedBindingValue));
         typed.OnNext(new(TypedBindingValue));
 
-        await Assert.That(untypedObserved!.Value.Value).IsEqualTo(UntypedBindingValue);
+        await Assert.That(untypedObserved!.Value.Value).IsEqualTo(TypedBindingValue);
         await Assert.That(typedObserved!.Value.Value).IsEqualTo(TypedBindingValue);
         await Assert.That(control.IntProp).IsEqualTo(TypedBindingValue);
     }

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveShimFullCoverageTestInfrastructure.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveShimFullCoverageTestInfrastructure.cs
@@ -159,7 +159,7 @@ public partial class ReactiveShimFullCoverageTests
         var assemblyName = new AssemblyName("ReactiveUI.Avalonia.Tests.ReactiveDynamicLifetime");
         var assembly = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
         var module = assembly.DefineDynamicModule("Main");
-        var type = module.DefineType("ReactiveUnsupportedLifetime", TypeAttributes.NotPublic | TypeAttributes.Sealed);
+        var type = module.DefineType("ReactiveUnsupportedLifetime", TypeAttributes.Sealed);
         type.AddInterfaceImplementation(typeof(IApplicationLifetime));
 
         var lifetimeType = type.CreateType();
@@ -167,23 +167,15 @@ public partial class ReactiveShimFullCoverageTests
     }
 
     /// <summary>Gets a real presentation source from a headless window.</summary>
-    /// <returns>The presentation source.</returns>
-    private static IPresentationSource GetPresentationSource()
+    /// <returns>The owner window and presentation source.</returns>
+    private static (Window Window, IPresentationSource Source) GetPresentationSource()
     {
         IPresentationSource? source = null;
         var control = new Control();
         control.AttachedToVisualTree += (_, args) => source = args.PresentationSource;
         var window = new Window { Content = control };
-
-        try
-        {
-            window.Show();
-            return source!;
-        }
-        finally
-        {
-            window.Close();
-        }
+        window.Show();
+        return (window, source!);
     }
 
     /// <summary>Executes an action and returns the expected invalid-operation exception.</summary>
@@ -530,18 +522,19 @@ public partial class ReactiveShimFullCoverageTests
 
         /// <inheritdoc/>
         public object? GetService(Type? serviceType) =>
-            throw new InvalidOperationException($"Cannot resolve {serviceType}.");
+            serviceType == typeof(ILogManager)
+                ? new FuncLogManager(static _ => new WrappingFullLogger(new NullLogger()))
+                : throw new InvalidOperationException($"Cannot resolve {serviceType}.");
 
         /// <inheritdoc/>
         public object? GetService(Type? serviceType, string? contract) =>
             throw new InvalidOperationException($"Cannot resolve {serviceType} for {contract}.");
 
         /// <inheritdoc/>
-        public T? GetService<T>()
-        {
-            _ = typeof(T);
-            return default;
-        }
+        public T? GetService<T>() =>
+            typeof(T) == typeof(ILogManager)
+                ? (T)(object)new FuncLogManager(static _ => new WrappingFullLogger(new NullLogger()))
+                : default;
 
         /// <inheritdoc/>
         public T? GetService<T>(string? contract) =>

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveShimFullCoverageTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveShimFullCoverageTests.cs
@@ -4,12 +4,10 @@
 using System.Linq.Expressions;
 using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
-using Avalonia.Rendering;
 using Splat;
 
 using ReactiveRxAppBuilder = global::ReactiveUI.Reactive.Builder.RxAppBuilder;
@@ -332,8 +330,8 @@ public partial class ReactiveShimFullCoverageTests
         await Assert.That(static () => new AutoSuspendHelper(null!)).ThrowsExactly<ArgumentNullException>();
         await Assert.That(static () => new AutoSuspendHelper(CreateUnsupportedLifetime())).ThrowsExactly<NotSupportedException>();
 
-        var lifetime = new ClassicDesktopStyleApplicationLifetime();
-        using var helper = new AutoSuspendHelper(lifetime);
+        var fixture = new ControlledLifetimeFixture();
+        using var helper = new AutoSuspendHelper(fixture.Lifetime);
         var persisted = false;
         using var persistSubscription = ReactiveRxSuspension.SuspensionHost.ShouldPersistState.Subscribe(
             new RecordingObserver<IDisposable>(value =>
@@ -342,7 +340,7 @@ public partial class ReactiveShimFullCoverageTests
                 value.Dispose();
             }));
 
-        lifetime.Shutdown();
+        fixture.RaiseExit();
         await Assert.That(persisted).IsTrue();
 
         var launches = 0;
@@ -428,7 +426,7 @@ public partial class ReactiveShimFullCoverageTests
         }
 
         await Assert.That(button.Command).IsNull();
-        await Assert.That(sut.BindCommandToObject(null, button, parameter)).IsNull();
+        await Assert.That(sut.BindCommandToObject(null, button, parameter)).IsNotNull();
         await Assert.That(sut.BindCommandToObject<Button>(command, null, parameter)).IsNull();
         await Assert.That(CaptureInvalidOperation(() => sut.BindCommandToObject<object>(command, new(), parameter))).IsNotNull();
         await Assert.That(CaptureInvalidOperation(() => sut.BindCommandToObject(command, new TextBox(), parameter))).IsNotNull();
@@ -513,16 +511,17 @@ public partial class ReactiveShimFullCoverageTests
         await Assert.That(control.ViewModel).IsSameReferenceAs(vm);
         await Assert.That(((IViewFor<ShimVm>)control).ViewModel).IsSameReferenceAs(vm);
 
-        control.DataContext = new();
+        var invalidDataContext = new object();
+        control.DataContext = invalidDataContext;
         await Assert.That(control.ViewModel).IsSameReferenceAs(vm);
 
         var secondVm = new ShimVm();
         control.ViewModel = secondVm;
-        await Assert.That(control.DataContext).IsSameReferenceAs(secondVm);
+        await Assert.That(control.DataContext).IsSameReferenceAs(invalidDataContext);
 
         ((IViewFor)control).ViewModel = null;
         await Assert.That(control.ViewModel).IsNull();
-        await Assert.That(control.DataContext).IsNull();
+        await Assert.That(control.DataContext).IsSameReferenceAs(invalidDataContext);
 
         var directControl = new ReactiveUserControl<ShimVm> { DataContext = vm };
         await Assert.That(directControl.ViewModel).IsSameReferenceAs(vm);
@@ -533,15 +532,16 @@ public partial class ReactiveShimFullCoverageTests
         await Assert.That(window.ViewModel).IsSameReferenceAs(vm);
         await Assert.That(((IViewFor<ShimVm>)window).ViewModel).IsSameReferenceAs(vm);
 
-        window.DataContext = new();
+        var invalidWindowDataContext = new object();
+        window.DataContext = invalidWindowDataContext;
         await Assert.That(window.ViewModel).IsSameReferenceAs(vm);
 
         window.ViewModel = secondVm;
-        await Assert.That(window.DataContext).IsSameReferenceAs(secondVm);
+        await Assert.That(window.DataContext).IsSameReferenceAs(invalidWindowDataContext);
 
         ((IViewFor)window).ViewModel = null;
         await Assert.That(window.ViewModel).IsNull();
-        await Assert.That(window.DataContext).IsNull();
+        await Assert.That(window.DataContext).IsSameReferenceAs(invalidWindowDataContext);
 
         var directWindow = new ReactiveWindow<ShimVm> { DataContext = vm };
         await Assert.That(directWindow.ViewModel).IsSameReferenceAs(vm);
@@ -617,10 +617,17 @@ public partial class ReactiveShimFullCoverageTests
 
         host.DisposeNavigationDisposables();
 
-        var source = GetPresentationSource();
-        host.Attach(source);
-        host.Attach(source);
-        host.Detach(source);
+        var (window, source) = GetPresentationSource();
+        try
+        {
+            host.Attach(source);
+            host.Attach(source);
+            host.Detach(source);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     /// <summary>Verifies reactive routed view-host navigation behavior.</summary>
@@ -675,10 +682,17 @@ public partial class ReactiveShimFullCoverageTests
 
         host.DisposeNavigationDisposables();
 
-        var source = GetPresentationSource();
-        host.Attach(source);
-        host.Attach(source);
-        host.Detach(source);
+        var (window, source) = GetPresentationSource();
+        try
+        {
+            host.Attach(source);
+            host.Attach(source);
+            host.Detach(source);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     /// <summary>Verifies reactive view hosts navigate through visual-tree subscriptions.</summary>
@@ -717,6 +731,150 @@ public partial class ReactiveShimFullCoverageTests
         finally
         {
             routedWindow.Close();
+        }
+    }
+
+    /// <summary>Verifies reactive RoutedViewHost displays navigation that happened before the host was attached.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task ReactiveRoutedViewHost_Navigates_WhenRouterAlreadyHasCurrentViewModel()
+    {
+        var screen = new ScreenImpl();
+        var vm = new VmA(screen);
+        _ = screen.Router.Navigate.Execute(vm).Subscribe();
+        var host = new TestableReactiveRoutedViewHost { DefaultContent = DefaultContentValue, Router = screen.Router, ViewLocator = new StaticViewLocator(new ViewA()) };
+        var window = new Window { Content = host };
+
+        try
+        {
+            await Assert.That(screen.Router.NavigationStack.Count).IsEqualTo(1);
+
+            window.Show();
+
+            await Assert.That(host.Content).IsTypeOf<ViewA>();
+            await Assert.That(((IViewFor)host.Content!).ViewModel).IsSameReferenceAs(vm);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies reactive RoutedViewHost displays an already-current view model when the router is assigned after attachment.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task ReactiveRoutedViewHost_Navigates_WhenAlreadyNavigatedRouterIsAssigned()
+    {
+        var screen = new ScreenImpl();
+        var vm = new VmA(screen);
+        _ = screen.Router.Navigate.Execute(vm).Subscribe();
+        var host = new TestableReactiveRoutedViewHost { DefaultContent = DefaultContentValue, ViewLocator = new StaticViewLocator(new ViewA()) };
+        var window = new Window { Content = host };
+
+        try
+        {
+            window.Show();
+            host.Router = screen.Router;
+
+            await Assert.That(screen.Router.NavigationStack.Count).IsEqualTo(1);
+            await Assert.That(host.Content).IsTypeOf<ViewA>();
+            await Assert.That(((IViewFor)host.Content!).ViewModel).IsSameReferenceAs(vm);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies reactive RoutedViewHost ignores navigation from a router after another router is assigned.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task ReactiveRoutedViewHost_IgnoresPreviousRouterAfterReplacement()
+    {
+        var firstScreen = new ScreenImpl();
+        var secondScreen = new ScreenImpl();
+        var firstVm = new VmA(firstScreen);
+        var secondVm = new VmA(secondScreen);
+        var view = new ViewA();
+        var host = new TestableReactiveRoutedViewHost { DefaultContent = DefaultContentValue, Router = firstScreen.Router, ViewLocator = new StaticViewLocator(view) };
+        var window = new Window { Content = host };
+
+        try
+        {
+            window.Show();
+            _ = firstScreen.Router.Navigate.Execute(firstVm).Subscribe();
+            await Assert.That(view.ViewModel).IsSameReferenceAs(firstVm);
+
+            host.Router = secondScreen.Router;
+            _ = secondScreen.Router.Navigate.Execute(secondVm).Subscribe();
+            await Assert.That(view.ViewModel).IsSameReferenceAs(secondVm);
+
+            _ = firstScreen.Router.Navigate.Execute(new VmA(firstScreen)).Subscribe();
+            await Assert.That(view.ViewModel).IsSameReferenceAs(secondVm);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies reactive RoutedViewHost ignores router navigation after the router is cleared.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task ReactiveRoutedViewHost_IgnoresPreviousRouterAfterRouterCleared()
+    {
+        var screen = new ScreenImpl();
+        var vm = new VmA(screen);
+        var view = new ViewA();
+        var host = new TestableReactiveRoutedViewHost { DefaultContent = DefaultContentValue, Router = screen.Router, ViewLocator = new StaticViewLocator(view) };
+        var window = new Window { Content = host };
+
+        try
+        {
+            window.Show();
+            _ = screen.Router.Navigate.Execute(vm).Subscribe();
+            await Assert.That(view.ViewModel).IsSameReferenceAs(vm);
+
+            host.Router = null;
+            _ = screen.Router.Navigate.Execute(new VmA(screen)).Subscribe();
+
+            await Assert.That(host.Content).IsEqualTo(DefaultContentValue);
+            await Assert.That(view.ViewModel).IsSameReferenceAs(vm);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies reactive RoutedViewHost ignores navigation while detached and catches up when reattached.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task ReactiveRoutedViewHost_CatchesUpToCurrentViewModelAfterReattach()
+    {
+        var screen = new ScreenImpl();
+        var firstVm = new VmA(screen);
+        var secondVm = new VmA(screen);
+        var view = new ViewA();
+        var host = new TestableReactiveRoutedViewHost { DefaultContent = DefaultContentValue, Router = screen.Router, ViewLocator = new StaticViewLocator(view) };
+        var window = new Window { Content = host };
+
+        try
+        {
+            window.Show();
+            _ = screen.Router.Navigate.Execute(firstVm).Subscribe();
+            await Assert.That(view.ViewModel).IsSameReferenceAs(firstVm);
+
+            window.Content = null;
+            _ = screen.Router.Navigate.Execute(secondVm).Subscribe();
+            await Assert.That(view.ViewModel).IsSameReferenceAs(firstVm);
+
+            window.Content = host;
+            await Assert.That(view.ViewModel).IsSameReferenceAs(secondVm);
+        }
+        finally
+        {
+            window.Close();
         }
     }
 

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveUserControlActivationTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveUserControlActivationTests.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using Avalonia.Controls;
+using Avalonia.Threading;
+using ReactiveUI.Reactive;
+
+namespace ReactiveUI.Avalonia.Reactive.Tests;
+
+/// <summary>Tests view-model activation without a custom control activation block.</summary>
+public sealed class ReactiveUserControlActivationTests
+{
+    /// <summary>Verifies the base control activates its view model when it becomes visible.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Base_Control_Activates_ViewModel_Without_Custom_View_Block()
+    {
+        using var model = new ActivatableModel();
+        var activationCount = 0;
+        model.WhenActivated((ReactiveUI.Primitives.Reactive.Disposables.ContainerDisposable disposables) => activationCount++);
+        var control = new ReactiveUserControl<ActivatableModel> { ViewModel = model };
+        var window = new Window { Content = control };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(activationCount).IsEqualTo(1);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>A view model that owns its activation lifetime.</summary>
+    private sealed class ActivatableModel : ReactiveObject, IActivatableViewModel, IDisposable
+    {
+        /// <inheritdoc/>
+        public ViewModelActivator Activator { get; } = new();
+
+        /// <inheritdoc/>
+        public void Dispose() => Activator.Dispose();
+    }
+}

--- a/src/tests/ReactiveUI.Avalonia.Tests/AppBuilderExtensionsTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/AppBuilderExtensionsTests.cs
@@ -29,7 +29,6 @@ public class AppBuilderExtensionsTests
         AppBuilderExtensions.ConfigureReactiveUI(_ => invoked = true);
 
         await Assert.That(invoked).IsTrue();
-        await Assert.That(AppLocator.Current.GetService<IActivationForViewFetcher>()).IsTypeOf<AvaloniaActivationForViewFetcher>();
     }
 
     /// <summary>Verifies that UseReactiveUI executes the callback without rebuilding when ReactiveUI is already built.</summary>

--- a/src/tests/ReactiveUI.Avalonia.Tests/AutoSuspendHelperShutdownTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/AutoSuspendHelperShutdownTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using Avalonia.Controls;
+
+namespace ReactiveUI.Avalonia.Tests;
+
+/// <summary>Regression tests for suspension helper shutdown and event ownership.</summary>
+public class AutoSuspendHelperShutdownTests
+{
+    /// <summary>Verifies designer initialization never subscribes to application shutdown.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Design_Mode_Does_Not_Persist_State()
+    {
+        var designMode = typeof(Design).GetProperty(nameof(Design.IsDesignMode))!;
+        var previous = Design.IsDesignMode;
+        try
+        {
+            designMode.SetValue(null, true);
+            var fixture = new ControlledLifetimeFixture();
+            using var helper = new AutoSuspendHelper(fixture.Lifetime);
+            fixture.RaiseExit();
+            await Assert.That(Design.IsDesignMode).IsTrue();
+        }
+        finally
+        {
+            designMode.SetValue(null, previous);
+        }
+    }
+
+    /// <summary>Verifies that shutdown completes when no persistence observer is registered.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Shutdown_WithoutPersistenceSubscribers_Completes()
+    {
+        var fixture = new ControlledLifetimeFixture();
+        using var helper = new AutoSuspendHelper(fixture.Lifetime);
+        var exited = false;
+        fixture.Lifetime.Exit += (_, _) => exited = true;
+
+        fixture.RaiseExit();
+
+        await Assert.That(exited).IsTrue();
+    }
+
+    /// <summary>Verifies that a disposed helper does not intercept application shutdown.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Dispose_RemovesLifetimeHandler()
+    {
+        var fixture = new ControlledLifetimeFixture();
+        var helper = new AutoSuspendHelper(fixture.Lifetime);
+        helper.Dispose();
+        var exited = false;
+        fixture.Lifetime.Exit += (_, _) => exited = true;
+
+        fixture.RaiseExit();
+
+        await Assert.That(exited).IsTrue();
+    }
+}

--- a/src/tests/ReactiveUI.Avalonia.Tests/AutoSuspendHelperTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/AutoSuspendHelperTests.cs
@@ -25,8 +25,8 @@ public class AutoSuspendHelperTests
     [Test]
     public async Task Ctor_With_DesktopLifetime_Sets_ShouldPersistState()
     {
-        var lifetime = new ClassicDesktopStyleApplicationLifetime();
-        using var helper = new AutoSuspendHelper(lifetime);
+        var fixture = new ControlledLifetimeFixture();
+        using var helper = new AutoSuspendHelper(fixture.Lifetime);
 
         var notified = false;
         var sub = RxSuspension.SuspensionHost.ShouldPersistState.SubscribeSafe(
@@ -35,9 +35,9 @@ public class AutoSuspendHelperTests
                 notified = true;
                 d.Dispose();
             },
-            static error => throw error);
+                static error => throw error);
 
-        lifetime.Shutdown();
+        fixture.RaiseExit();
 
         await Assert.That(notified).IsTrue();
         sub.Dispose();
@@ -85,7 +85,7 @@ public class AutoSuspendHelperTests
         var assemblyName = new AssemblyName("ReactiveUI.Avalonia.Tests.DynamicLifetime");
         var assembly = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
         var module = assembly.DefineDynamicModule("Main");
-        var type = module.DefineType("UnsupportedLifetime", TypeAttributes.NotPublic | TypeAttributes.Sealed);
+        var type = module.DefineType("UnsupportedLifetime", TypeAttributes.Sealed);
         type.AddInterfaceImplementation(typeof(IApplicationLifetime));
 
         var lifetimeType = type.CreateType();

--- a/src/tests/ReactiveUI.Avalonia.Tests/AutofacIsolatedTestExecutor.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/AutofacIsolatedTestExecutor.cs
@@ -20,7 +20,7 @@ public class AutofacIsolatedTestExecutor : ITestExecutor
         ArgumentNullException.ThrowIfNull(action);
 
         // Run on the shared headless UI thread for consistency with AvaloniaTestExecutor.
-        await AvaloniaTestSession.Instance.Dispatch(
+        _ = await AvaloniaTestSession.Instance.Dispatch(
             async () =>
             {
                 var originalLocator = Locator.GetLocator();
@@ -39,6 +39,8 @@ public class AutofacIsolatedTestExecutor : ITestExecutor
                         .WithCoreServices()
                         .BuildApp();
                 }
+
+                return true;
             },
             CancellationToken.None);
     }

--- a/src/tests/ReactiveUI.Avalonia.Tests/AvaloniaCreatesCommandBindingNullCommandTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/AvaloniaCreatesCommandBindingNullCommandTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using Avalonia.Controls;
+
+namespace ReactiveUI.Avalonia.Tests;
+
+/// <summary>Regression tests for null command updates in Avalonia command bindings.</summary>
+public class AvaloniaCreatesCommandBindingNullCommandTests
+{
+    /// <summary>Verifies that a null command removes a previous command and remains removed when its earlier binding is disposed.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommandToObject_NullCommand_ClearsPreviousCommandAndSurvivesPriorBindingDisposal()
+    {
+        var sut = new AvaloniaCreatesCommandBinding();
+        var button = new Button();
+        var parameter = new Signal<object?>();
+        var command = new TestCommand();
+
+        using var emptyBinding = sut.BindCommandToObject(null, button, parameter);
+        await Assert.That(emptyBinding).IsNotNull();
+        await Assert.That(button.Command).IsNull();
+
+        var binding = sut.BindCommandToObject(command, button, parameter)!;
+        await Assert.That(button.Command).IsSameReferenceAs(command);
+
+        using var clearedBinding = sut.BindCommandToObject(null, button, parameter);
+        await Assert.That(clearedBinding).IsNotNull();
+        await Assert.That(button.Command).IsNull();
+
+        binding.Dispose();
+        await Assert.That(button.Command).IsNull();
+    }
+
+    /// <summary>Verifies that disposing a binding preserves a command assigned after that binding was created.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommandToObject_Disposal_PreservesReplacementCommand()
+    {
+        var sut = new AvaloniaCreatesCommandBinding();
+        var button = new Button();
+        var parameter = new Signal<object?>();
+        var initialCommand = new TestCommand();
+        var replacementCommand = new TestCommand();
+
+        var binding = sut.BindCommandToObject(initialCommand, button, parameter)!;
+        button.Command = replacementCommand;
+
+        binding.Dispose();
+
+        await Assert.That(button.Command).IsSameReferenceAs(replacementCommand);
+    }
+
+    /// <summary>Verifies the public BindCommand pipeline updates a button when a nullable view-model command changes.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task BindCommand_NullableViewModelCommand_TransitionsFromNullToCommandAndBack()
+    {
+        var viewModel = new CommandViewModel();
+        var view = new CommandView { ViewModel = viewModel };
+        var command = new TestCommand();
+
+        using (view.BindCommand(viewModel, static x => x.Command, static x => x.Button))
+        {
+            await Assert.That(view.Button.Command).IsNull();
+
+            viewModel.Command = command;
+            await Assert.That(view.Button.Command).IsSameReferenceAs(command);
+
+            view.Button.Command!.Execute(null);
+            await Assert.That(command.ExecutionCount).IsEqualTo(1);
+
+            viewModel.Command = null;
+            await Assert.That(view.Button.Command).IsNull();
+        }
+    }
+
+    /// <summary>A view model with the nullable command property used by the public binding regression.</summary>
+    private sealed class CommandViewModel : ReactiveObject
+    {
+        /// <summary>Gets or sets the command bound to the test button.</summary>
+        public System.Windows.Input.ICommand? Command
+        {
+            get;
+            set => this.RaiseAndSetIfChanged(ref field, value);
+        }
+    }
+
+    /// <summary>A view exposing the test button to the public command-binding extension.</summary>
+    private sealed class CommandView : ReactiveUserControl<CommandViewModel>
+    {
+        /// <summary>Gets the button bound by the test.</summary>
+        public Button Button { get; } = new();
+    }
+
+    /// <summary>A minimal command implementation for command property assertions.</summary>
+    private sealed class TestCommand : System.Windows.Input.ICommand
+    {
+        /// <inheritdoc/>
+        public event EventHandler? CanExecuteChanged
+        {
+            add { }
+            remove { }
+        }
+
+        /// <summary>Gets the number of times the command has executed.</summary>
+        public int ExecutionCount { get; private set; }
+
+        /// <inheritdoc/>
+        public bool CanExecute(object? parameter) => true;
+
+        /// <inheritdoc/>
+        public void Execute(object? parameter) => ExecutionCount++;
+    }
+}

--- a/src/tests/ReactiveUI.Avalonia.Tests/AvaloniaMixinsAutofacTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/AvaloniaMixinsAutofacTests.cs
@@ -5,6 +5,7 @@ extern alias autofac;
 
 using Autofac;
 using Avalonia;
+using ReactiveUI.Builder;
 using Splat;
 using Splat.Autofac;
 using TUnit.Core.Executors;
@@ -60,6 +61,84 @@ public class AvaloniaMixinsAutofacTests
             static rx => _ = rx is not null);
 
         await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    /// <summary>Verifies that the simple overload defers to the full overload.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithAutofac_SimpleOverload_ReturnsBuilder()
+    {
+        var builder = AppBuilder.Configure<Application>();
+        var result = AvaloniaMixins.UseReactiveUIWithAutofac(builder, static _ => { });
+
+        await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    /// <summary>Verifies that null container configuration is validated immediately.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task UseReactiveUIWithAutofac_ThrowsOnNullContainerConfig()
+    {
+        var builder = AppBuilder.Configure<Application>();
+
+        await Assert.That(() => AvaloniaMixins.UseReactiveUIWithAutofac(builder, null!, null, null))
+            .ThrowsExactly<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that Autofac registration executes through the deferred platform setup callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [TestExecutor<AutofacIsolatedTestExecutor>]
+    public async Task UseReactiveUIWithAutofac_AfterPlatformCallback_ConfiguresContainerAndResolver()
+    {
+        ReactiveUIBuilder.ResetBuilderStateForTests();
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+        var resolverCalled = false;
+        var reactiveBuilderCalled = false;
+
+        try
+        {
+            _ = AvaloniaMixins.UseReactiveUIWithAutofac(
+                builder,
+                containerConfig: containerBuilder =>
+                {
+                    configCalled = true;
+                    _ = containerBuilder.RegisterInstance("configured");
+                },
+                withResolver: resolver => resolverCalled = resolver is not null,
+                withReactiveUIBuilder: _ => reactiveBuilderCalled = true);
+
+            builder.AfterPlatformServicesSetupCallback!(builder);
+
+            await Assert.That(configCalled).IsTrue();
+            await Assert.That(resolverCalled).IsTrue();
+            await Assert.That(reactiveBuilderCalled).IsTrue();
+        }
+        finally
+        {
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
+    }
+
+    /// <summary>Verifies that the deferred callback handles an already-built app and null optional callbacks.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [TestExecutor<AutofacIsolatedTestExecutor>]
+    public async Task UseReactiveUIWithAutofac_AfterPlatformCallback_WhenAlreadyBuilt_AllowsNullCallbacks()
+    {
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+
+        _ = AvaloniaMixins.UseReactiveUIWithAutofac(
+            builder,
+            containerConfig: _ => configCalled = true,
+            withResolver: null,
+            withReactiveUIBuilder: null);
+
+        builder.AfterPlatformServicesSetupCallback!(builder);
+
+        await Assert.That(configCalled).IsTrue();
     }
 
     /// <summary>

--- a/src/tests/ReactiveUI.Avalonia.Tests/AvaloniaMixinsNinjectTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/AvaloniaMixinsNinjectTests.cs
@@ -4,6 +4,8 @@
 extern alias ninject;
 
 using Avalonia;
+using ReactiveUI.Builder;
+using TUnit.Core.Executors;
 using AvaloniaMixins = ninject::ReactiveUI.Avalonia.Splat.AvaloniaMixins;
 
 namespace ReactiveUI.Avalonia.Tests;
@@ -52,5 +54,66 @@ public class AvaloniaMixinsNinjectTests
             static _ => { },
             static rx => _ = rx is not null);
         await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    /// <summary>Verifies that null container configuration is validated by the deferred callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [TestExecutor<AutofacIsolatedTestExecutor>]
+    public async Task UseReactiveUIWithNinject_AfterPlatformCallback_ThrowsOnNullContainerConfig()
+    {
+        var builder = AppBuilder.Configure<Application>();
+        _ = AvaloniaMixins.UseReactiveUIWithNinject(builder, null!, null);
+
+        await Assert.That(() => builder.AfterPlatformServicesSetupCallback!(builder))
+            .ThrowsExactly<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that Ninject registration executes through the deferred platform setup callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [TestExecutor<AutofacIsolatedTestExecutor>]
+    public async Task UseReactiveUIWithNinject_AfterPlatformCallback_ConfiguresContainer()
+    {
+        ReactiveUIBuilder.ResetBuilderStateForTests();
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+        var reactiveBuilderCalled = false;
+
+        try
+        {
+            _ = AvaloniaMixins.UseReactiveUIWithNinject(
+                builder,
+                containerConfig: kernel => configCalled = kernel is not null,
+                withReactiveUIBuilder: _ => reactiveBuilderCalled = true);
+
+            builder.AfterPlatformServicesSetupCallback!(builder);
+
+            await Assert.That(configCalled).IsTrue();
+            await Assert.That(reactiveBuilderCalled).IsTrue();
+        }
+        finally
+        {
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
+    }
+
+    /// <summary>Verifies that the deferred callback handles an already-built app and a null ReactiveUI callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [TestExecutor<AutofacIsolatedTestExecutor>]
+    public async Task UseReactiveUIWithNinject_AfterPlatformCallback_WhenAlreadyBuilt_AllowsNullCallback()
+    {
+        var builder = AppBuilder.Configure<Application>();
+        var configCalled = false;
+
+        _ = AvaloniaMixins.UseReactiveUIWithNinject(
+            builder,
+            containerConfig: kernel => configCalled = kernel is not null,
+            withReactiveUIBuilder: null);
+
+        builder.AfterPlatformServicesSetupCallback!(builder);
+
+        await Assert.That(configCalled).IsTrue();
     }
 }

--- a/src/tests/ReactiveUI.Avalonia.Tests/AvaloniaTestExecutor.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/AvaloniaTestExecutor.cs
@@ -17,7 +17,7 @@ public class AvaloniaTestExecutor : ITestExecutor
 
         // Run the test body on the shared headless UI thread so dispatcher-dependent code
         // (e.g. AvaloniaScheduler) behaves deterministically. See AvaloniaTestSession.
-        await AvaloniaTestSession.Instance.Dispatch(
+        _ = await AvaloniaTestSession.Instance.Dispatch(
             async () =>
             {
                 ReactiveUIBuilder.ResetBuilderStateForTests();
@@ -46,6 +46,8 @@ public class AvaloniaTestExecutor : ITestExecutor
                         .WithCoreServices()
                         .BuildApp();
                 }
+
+                return true;
             },
             CancellationToken.None);
     }

--- a/src/tests/ReactiveUI.Avalonia.Tests/AvaloniaTestSession.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/AvaloniaTestSession.cs
@@ -24,7 +24,7 @@ internal static class AvaloniaTestSession
 {
     /// <summary>The lazily-created, process-wide headless session backing <see cref="Instance"/>.</summary>
     private static readonly Lazy<HeadlessUnitTestSession> _session =
-        new(static () => HeadlessUnitTestSession.StartNew(typeof(Application)), LazyThreadSafetyMode.ExecutionAndPublication);
+        new(static () => HeadlessUnitTestSession.StartNew(typeof(Application), AvaloniaTestIsolationLevel.PerAssembly), LazyThreadSafetyMode.ExecutionAndPublication);
 
     /// <summary>Gets the shared headless session, creating it on first access.</summary>
     internal static HeadlessUnitTestSession Instance => _session.Value;

--- a/src/tests/ReactiveUI.Avalonia.Tests/AvaloniaUIThreadTestsMain.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/AvaloniaUIThreadTestsMain.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 using System.Diagnostics;
+using Avalonia.Threading;
 using ReactiveUI.Primitives.Concurrency;
 
 namespace ReactiveUI.Avalonia.Tests;
@@ -68,11 +69,13 @@ public class AvaloniaUIThreadTestsMain
     public async Task AvaloniaScheduler_ScheduleWorkItem_Executes()
     {
         var scheduler = AvaloniaScheduler.Instance;
-        var executed = false;
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        scheduler.Schedule(new WorkItem(() => executed = true));
+        scheduler.Schedule(new WorkItem(() => completion.SetResult()));
+        Dispatcher.UIThread.RunJobs();
 
-        await Assert.That(executed).IsTrue();
+        await completion.Task.WaitAsync(TimeSpan.FromSeconds(ScheduleTimeoutSeconds));
+        await Assert.That(completion.Task.IsCompletedSuccessfully).IsTrue();
     }
 
     /// <summary>Verifies that Schedule with a timestamp throws ArgumentNullException for a null work item.</summary>
@@ -91,11 +94,13 @@ public class AvaloniaUIThreadTestsMain
     public async Task AvaloniaScheduler_ScheduleWorkItemWithPastTimestamp_Executes()
     {
         var scheduler = AvaloniaScheduler.Instance;
-        var executed = false;
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        scheduler.Schedule(new WorkItem(() => executed = true), scheduler.Timestamp - 1);
+        scheduler.Schedule(new WorkItem(() => completion.SetResult()), scheduler.Timestamp - 1);
+        Dispatcher.UIThread.RunJobs();
 
-        await Assert.That(executed).IsTrue();
+        await completion.Task.WaitAsync(TimeSpan.FromSeconds(ScheduleTimeoutSeconds));
+        await Assert.That(completion.Task.IsCompletedSuccessfully).IsTrue();
     }
 
     /// <summary>Verifies that Schedule with a future timestamp executes after the delay.</summary>
@@ -107,6 +112,7 @@ public class AvaloniaUIThreadTestsMain
         var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         scheduler.Schedule(new WorkItem(() => completion.SetResult()), scheduler.Timestamp + StopwatchTicks(FutureScheduleDelayMilliseconds));
+        Dispatcher.UIThread.RunJobs();
 
         await completion.Task.WaitAsync(TimeSpan.FromSeconds(ScheduleTimeoutSeconds));
         await Assert.That(completion.Task.IsCompletedSuccessfully).IsTrue();

--- a/src/tests/ReactiveUI.Avalonia.Tests/ControlledLifetimeFixture.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/ControlledLifetimeFixture.cs
@@ -1,0 +1,366 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+
+namespace ReactiveUI.Avalonia.Tests;
+
+/// <summary>Provides a controlled desktop lifetime implementation for shutdown tests.</summary>
+public sealed class ControlledLifetimeFixture
+{
+    /// <summary>Method attributes used for emitted interface implementations.</summary>
+    private const MethodAttributes InterfaceImplementationAttributes = MethodAttributes.Public
+        | MethodAttributes.Virtual
+        | MethodAttributes.Final
+        | MethodAttributes.HideBySig;
+
+    /// <summary>Stores event handlers for each dynamic lifetime instance.</summary>
+    private static readonly ConditionalWeakTable<object, LifetimeEvents> s_events = [];
+
+    /// <summary>Stores the generated lifetime implementation type.</summary>
+    private static readonly Lazy<Type> s_lifetimeType = new(CreateLifetimeType);
+
+    /// <summary>Initializes a new instance of the <see cref="ControlledLifetimeFixture"/> class.</summary>
+    public ControlledLifetimeFixture() =>
+        Lifetime = (IClassicDesktopStyleApplicationLifetime)Activator.CreateInstance(s_lifetimeType.Value)!;
+
+    /// <summary>Gets the dynamically generated desktop lifetime.</summary>
+    public IClassicDesktopStyleApplicationLifetime Lifetime { get; }
+
+    /// <summary>Adds a startup event handler to the dynamic lifetime.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <param name="handler">The handler to add.</param>
+    public static void AddStartup(object instance, EventHandler<ControlledApplicationLifetimeStartupEventArgs> handler) =>
+        GetEvents(instance).AddStartup(handler);
+
+    /// <summary>Removes a startup event handler from the dynamic lifetime.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <param name="handler">The handler to remove.</param>
+    public static void RemoveStartup(object instance, EventHandler<ControlledApplicationLifetimeStartupEventArgs> handler) =>
+        GetEvents(instance).RemoveStartup(handler);
+
+    /// <summary>Adds an exit event handler to the dynamic lifetime.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <param name="handler">The handler to add.</param>
+    public static void AddExit(object instance, EventHandler<ControlledApplicationLifetimeExitEventArgs> handler) =>
+        GetEvents(instance).AddExit(handler);
+
+    /// <summary>Removes an exit event handler from the dynamic lifetime.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <param name="handler">The handler to remove.</param>
+    public static void RemoveExit(object instance, EventHandler<ControlledApplicationLifetimeExitEventArgs> handler) =>
+        GetEvents(instance).RemoveExit(handler);
+
+    /// <summary>Adds a shutdown-requested event handler to the dynamic lifetime.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <param name="handler">The handler to add.</param>
+    public static void AddShutdownRequested(object instance, EventHandler<ShutdownRequestedEventArgs> handler) =>
+        GetEvents(instance).AddShutdownRequested(handler);
+
+    /// <summary>Removes a shutdown-requested event handler from the dynamic lifetime.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <param name="handler">The handler to remove.</param>
+    public static void RemoveShutdownRequested(object instance, EventHandler<ShutdownRequestedEventArgs> handler) =>
+        GetEvents(instance).RemoveShutdownRequested(handler);
+
+    /// <summary>Raises the exit event on a dynamic lifetime instance.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <param name="exitCode">The exit code to publish.</param>
+    public static void RaiseExit(object instance, int exitCode) => GetEvents(instance).RaiseExit(instance, exitCode);
+
+    /// <summary>Raises the exit event on the dynamic lifetime.</summary>
+    public void RaiseExit() => RaiseExit(Lifetime, 0);
+
+    /// <summary>Raises the exit event on the dynamic lifetime.</summary>
+    /// <param name="exitCode">The exit code to publish.</param>
+    public void RaiseExit(int exitCode) => RaiseExit(Lifetime, exitCode);
+
+    /// <summary>Gets the event store for a dynamic lifetime instance.</summary>
+    /// <param name="instance">The dynamic lifetime instance.</param>
+    /// <returns>The event store associated with the instance.</returns>
+    private static LifetimeEvents GetEvents(object instance) => s_events.GetValue(instance, static _ => new LifetimeEvents());
+
+    /// <summary>Creates the dynamic lifetime implementation type.</summary>
+    /// <returns>A type implementing the Avalonia desktop lifetime interface.</returns>
+    private static Type CreateLifetimeType()
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new("ReactiveUI.Avalonia.Tests.ControlledLifetime"),
+            AssemblyBuilderAccess.Run);
+        var module = assembly.DefineDynamicModule("Main");
+        var type = module.DefineType(
+            "ControlledDesktopStyleApplicationLifetime",
+            TypeAttributes.Public | TypeAttributes.Sealed);
+        type.AddInterfaceImplementation(typeof(IClassicDesktopStyleApplicationLifetime));
+
+        ImplementMethodCall(type, typeof(IControlledApplicationLifetime).GetMethod("add_Startup")!, nameof(AddStartup));
+        ImplementMethodCall(type, typeof(IControlledApplicationLifetime).GetMethod("remove_Startup")!, nameof(RemoveStartup));
+        ImplementMethodCall(type, typeof(IControlledApplicationLifetime).GetMethod("add_Exit")!, nameof(AddExit));
+        ImplementMethodCall(type, typeof(IControlledApplicationLifetime).GetMethod("remove_Exit")!, nameof(RemoveExit));
+        ImplementMethodCall(
+            type,
+            typeof(IControlledApplicationLifetime).GetMethod(nameof(IControlledApplicationLifetime.Shutdown))!,
+            nameof(RaiseExit));
+        ImplementTryShutdown(type);
+        ImplementStringArrayGetter(type, nameof(IClassicDesktopStyleApplicationLifetime.Args));
+        ImplementShutdownModeProperty(type);
+        ImplementMainWindowProperty(type);
+        ImplementWindowsGetter(type);
+        ImplementMethodCall(
+            type,
+            typeof(IClassicDesktopStyleApplicationLifetime).GetMethod("add_ShutdownRequested")!,
+            nameof(AddShutdownRequested));
+        ImplementMethodCall(
+            type,
+            typeof(IClassicDesktopStyleApplicationLifetime).GetMethod("remove_ShutdownRequested")!,
+            nameof(RemoveShutdownRequested));
+
+        return type.CreateType();
+    }
+
+    /// <summary>Implements an interface method by forwarding to a static helper method.</summary>
+    /// <param name="type">The type builder to update.</param>
+    /// <param name="interfaceMethod">The interface method to implement.</param>
+    /// <param name="targetName">The target static helper method name.</param>
+    private static void ImplementMethodCall(TypeBuilder type, MethodInfo interfaceMethod, string targetName)
+    {
+        var parameterTypes = GetParameterTypes(interfaceMethod);
+        var method = type.DefineMethod(
+            interfaceMethod.Name,
+            GetImplementationAttributes(interfaceMethod),
+            interfaceMethod.ReturnType,
+            parameterTypes);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        for (var i = 0; i < parameterTypes.Length; i++)
+        {
+            il.Emit(OpCodes.Ldarg, i + 1);
+        }
+
+        il.Emit(OpCodes.Call, GetStaticHelper(targetName, parameterTypes));
+        il.Emit(OpCodes.Ret);
+        type.DefineMethodOverride(method, interfaceMethod);
+    }
+
+    /// <summary>Implements the desktop lifetime TryShutdown method.</summary>
+    /// <param name="type">The type builder to update.</param>
+    private static void ImplementTryShutdown(TypeBuilder type)
+    {
+        var interfaceMethod = typeof(IClassicDesktopStyleApplicationLifetime).GetMethod(
+            nameof(IClassicDesktopStyleApplicationLifetime.TryShutdown))!;
+        var method = type.DefineMethod(
+            interfaceMethod.Name,
+            GetImplementationAttributes(interfaceMethod),
+            typeof(bool),
+            [typeof(int)]);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, typeof(ControlledLifetimeFixture).GetMethod(nameof(RaiseExit), [typeof(object), typeof(int)])!);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+        type.DefineMethodOverride(method, interfaceMethod);
+    }
+
+    /// <summary>Implements a string array property getter.</summary>
+    /// <param name="type">The type builder to update.</param>
+    /// <param name="propertyName">The property name.</param>
+    private static void ImplementStringArrayGetter(TypeBuilder type, string propertyName)
+    {
+        var interfaceMethod = typeof(IClassicDesktopStyleApplicationLifetime).GetMethod($"get_{propertyName}")!;
+        var method = type.DefineMethod(
+            interfaceMethod.Name,
+            GetImplementationAttributes(interfaceMethod),
+            typeof(string[]),
+            Type.EmptyTypes);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Call, typeof(Array).GetMethod(nameof(Array.Empty))!.MakeGenericMethod(typeof(string)));
+        il.Emit(OpCodes.Ret);
+        type.DefineMethodOverride(method, interfaceMethod);
+    }
+
+    /// <summary>Implements the ShutdownMode property.</summary>
+    /// <param name="type">The type builder to update.</param>
+    private static void ImplementShutdownModeProperty(TypeBuilder type)
+    {
+        var field = type.DefineField("_shutdownMode", typeof(ShutdownMode), FieldAttributes.Private);
+        ImplementFieldGetter(
+            type,
+            typeof(IClassicDesktopStyleApplicationLifetime).GetMethod(
+                $"get_{nameof(IClassicDesktopStyleApplicationLifetime.ShutdownMode)}")!,
+            field);
+        ImplementFieldSetter(
+            type,
+            typeof(IClassicDesktopStyleApplicationLifetime).GetMethod(
+                $"set_{nameof(IClassicDesktopStyleApplicationLifetime.ShutdownMode)}")!,
+            field);
+    }
+
+    /// <summary>Implements the MainWindow property.</summary>
+    /// <param name="type">The type builder to update.</param>
+    private static void ImplementMainWindowProperty(TypeBuilder type)
+    {
+        var field = type.DefineField("_mainWindow", typeof(Window), FieldAttributes.Private);
+        ImplementFieldGetter(
+            type,
+            typeof(IClassicDesktopStyleApplicationLifetime).GetMethod(
+                $"get_{nameof(IClassicDesktopStyleApplicationLifetime.MainWindow)}")!,
+            field);
+        ImplementFieldSetter(
+            type,
+            typeof(IClassicDesktopStyleApplicationLifetime).GetMethod(
+                $"set_{nameof(IClassicDesktopStyleApplicationLifetime.MainWindow)}")!,
+            field);
+    }
+
+    /// <summary>Implements a field-backed getter.</summary>
+    /// <param name="type">The type builder to update.</param>
+    /// <param name="interfaceMethod">The interface getter to implement.</param>
+    /// <param name="field">The backing field.</param>
+    private static void ImplementFieldGetter(TypeBuilder type, MethodInfo interfaceMethod, FieldInfo field)
+    {
+        var method = type.DefineMethod(
+            interfaceMethod.Name,
+            GetImplementationAttributes(interfaceMethod),
+            interfaceMethod.ReturnType,
+            Type.EmptyTypes);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, field);
+        il.Emit(OpCodes.Ret);
+        type.DefineMethodOverride(method, interfaceMethod);
+    }
+
+    /// <summary>Implements a field-backed setter.</summary>
+    /// <param name="type">The type builder to update.</param>
+    /// <param name="interfaceMethod">The interface setter to implement.</param>
+    /// <param name="field">The backing field.</param>
+    private static void ImplementFieldSetter(TypeBuilder type, MethodInfo interfaceMethod, FieldInfo field)
+    {
+        var method = type.DefineMethod(
+            interfaceMethod.Name,
+            GetImplementationAttributes(interfaceMethod),
+            typeof(void),
+            [field.FieldType]);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Stfld, field);
+        il.Emit(OpCodes.Ret);
+        type.DefineMethodOverride(method, interfaceMethod);
+    }
+
+    /// <summary>Implements the Windows property getter.</summary>
+    /// <param name="type">The type builder to update.</param>
+    private static void ImplementWindowsGetter(TypeBuilder type)
+    {
+        var interfaceMethod = typeof(IClassicDesktopStyleApplicationLifetime).GetMethod(
+            $"get_{nameof(IClassicDesktopStyleApplicationLifetime.Windows)}")!;
+        var method = type.DefineMethod(
+            interfaceMethod.Name,
+            GetImplementationAttributes(interfaceMethod),
+            interfaceMethod.ReturnType,
+            Type.EmptyTypes);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Call, typeof(Array).GetMethod(nameof(Array.Empty))!.MakeGenericMethod(typeof(Window)));
+        il.Emit(OpCodes.Ret);
+        type.DefineMethodOverride(method, interfaceMethod);
+    }
+
+    /// <summary>Gets implementation method attributes for an interface method.</summary>
+    /// <param name="interfaceMethod">The interface method to implement.</param>
+    /// <returns>The method attributes to use for the emitted method.</returns>
+    private static MethodAttributes GetImplementationAttributes(MethodInfo interfaceMethod)
+    {
+        var attributes = InterfaceImplementationAttributes;
+        if (interfaceMethod.IsSpecialName)
+        {
+            attributes |= MethodAttributes.SpecialName;
+        }
+
+        return attributes;
+    }
+
+    /// <summary>Gets a static helper method with an emitted-instance leading parameter.</summary>
+    /// <param name="targetName">The target method name.</param>
+    /// <param name="parameterTypes">The interface parameter types.</param>
+    /// <returns>The matching static helper method.</returns>
+    private static MethodInfo GetStaticHelper(string targetName, Type[] parameterTypes)
+    {
+        var helperParameterTypes = new Type[parameterTypes.Length + 1];
+        helperParameterTypes[0] = typeof(object);
+        for (var i = 0; i < parameterTypes.Length; i++)
+        {
+            helperParameterTypes[i + 1] = parameterTypes[i];
+        }
+
+        return typeof(ControlledLifetimeFixture).GetMethod(targetName, helperParameterTypes)!;
+    }
+
+    /// <summary>Gets parameter types for a reflected method.</summary>
+    /// <param name="method">The method to inspect.</param>
+    /// <returns>The method parameter types.</returns>
+    private static Type[] GetParameterTypes(MethodInfo method)
+    {
+        var parameters = method.GetParameters();
+        var parameterTypes = new Type[parameters.Length];
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            parameterTypes[i] = parameters[i].ParameterType;
+        }
+
+        return parameterTypes;
+    }
+
+    /// <summary>Stores event handlers for a dynamic lifetime instance.</summary>
+    private sealed class LifetimeEvents
+    {
+        /// <summary>Stores startup handlers for the dynamic lifetime.</summary>
+        private EventHandler<ControlledApplicationLifetimeStartupEventArgs>? _startupHandler;
+
+        /// <summary>Stores exit handlers for the dynamic lifetime.</summary>
+        private EventHandler<ControlledApplicationLifetimeExitEventArgs>? _exitHandler;
+
+        /// <summary>Stores shutdown-requested handlers for the dynamic lifetime.</summary>
+        private EventHandler<ShutdownRequestedEventArgs>? _shutdownRequestedHandler;
+
+        /// <summary>Adds a startup handler.</summary>
+        /// <param name="handler">The handler to add.</param>
+        public void AddStartup(EventHandler<ControlledApplicationLifetimeStartupEventArgs> handler) =>
+            _startupHandler += handler;
+
+        /// <summary>Removes a startup handler.</summary>
+        /// <param name="handler">The handler to remove.</param>
+        public void RemoveStartup(EventHandler<ControlledApplicationLifetimeStartupEventArgs> handler) =>
+            _startupHandler -= handler;
+
+        /// <summary>Adds an exit handler.</summary>
+        /// <param name="handler">The handler to add.</param>
+        public void AddExit(EventHandler<ControlledApplicationLifetimeExitEventArgs> handler) =>
+            _exitHandler += handler;
+
+        /// <summary>Removes an exit handler.</summary>
+        /// <param name="handler">The handler to remove.</param>
+        public void RemoveExit(EventHandler<ControlledApplicationLifetimeExitEventArgs> handler) =>
+            _exitHandler -= handler;
+
+        /// <summary>Adds a shutdown-requested handler.</summary>
+        /// <param name="handler">The handler to add.</param>
+        public void AddShutdownRequested(EventHandler<ShutdownRequestedEventArgs> handler) =>
+            _shutdownRequestedHandler += handler;
+
+        /// <summary>Removes a shutdown-requested handler.</summary>
+        /// <param name="handler">The handler to remove.</param>
+        public void RemoveShutdownRequested(EventHandler<ShutdownRequestedEventArgs> handler) =>
+            _shutdownRequestedHandler -= handler;
+
+        /// <summary>Raises the stored exit handlers.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="exitCode">The exit code to publish.</param>
+        public void RaiseExit(object sender, int exitCode) => _exitHandler?.Invoke(sender, new(exitCode));
+    }
+}

--- a/src/tests/ReactiveUI.Avalonia.Tests/ReactiveUserControlActivationTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/ReactiveUserControlActivationTests.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using Avalonia.Controls;
+using Avalonia.Threading;
+using ReactiveUI;
+
+namespace ReactiveUI.Avalonia.Tests;
+
+/// <summary>Tests view-model activation without a custom control activation block.</summary>
+public sealed class ReactiveUserControlActivationTests
+{
+    /// <summary>Verifies the base control activates its view model when it becomes visible.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task Base_Control_Activates_ViewModel_Without_Custom_View_Block()
+    {
+        using var model = new ActivatableModel();
+        var activationCount = 0;
+        model.WhenActivated((MultipleDisposable disposables) => activationCount++);
+        var control = new ReactiveUserControl<ActivatableModel> { ViewModel = model };
+        var window = new Window { Content = control };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(activationCount).IsEqualTo(1);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>A view model that owns its activation lifetime.</summary>
+    private sealed class ActivatableModel : ReactiveObject, IActivatableViewModel, IDisposable
+    {
+        /// <inheritdoc/>
+        public ViewModelActivator Activator { get; } = new();
+
+        /// <inheritdoc/>
+        public void Dispose() => Activator.Dispose();
+    }
+}

--- a/src/tests/ReactiveUI.Avalonia.Tests/ReactiveWindowActivationTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/ReactiveWindowActivationTests.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 using System.Reflection;
+using Avalonia.Threading;
 
 namespace ReactiveUI.Avalonia.Tests;
 
@@ -41,6 +42,7 @@ public class ReactiveWindowActivationTests
         try
         {
             window.Show();
+            Dispatcher.UIThread.RunJobs();
 
             await Assert.That(activationCount).IsGreaterThan(0);
         }

--- a/src/tests/ReactiveUI.Avalonia.Tests/ReactiveWindowUserControlBindingTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/ReactiveWindowUserControlBindingTests.cs
@@ -150,6 +150,42 @@ public class ReactiveWindowUserControlBindingTests
         await Assert.That(((IViewFor)window).ViewModel).IsSameReferenceAs(vm);
     }
 
+    /// <summary>Verifies that the non-generic control propagates replacements and clearing through IViewFor.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task ReactiveUserControlBase_IViewFor_Replaces_And_Clears_DataContext()
+    {
+        var control = new BaseC();
+        var view = (IViewFor)control;
+        var first = new object();
+        var second = new object();
+
+        view.ViewModel = first;
+        await Assert.That(control.DataContext).IsSameReferenceAs(first);
+        view.ViewModel = second;
+        await Assert.That(control.DataContext).IsSameReferenceAs(second);
+        control.DataContext = null;
+        await Assert.That(view.ViewModel).IsNull();
+    }
+
+    /// <summary>Verifies that the non-generic window propagates replacements and clearing through IViewFor.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task ReactiveWindowBase_IViewFor_Replaces_And_Clears_DataContext()
+    {
+        var window = new BaseW();
+        var view = (IViewFor)window;
+        var first = new object();
+        var second = new object();
+
+        view.ViewModel = first;
+        await Assert.That(window.DataContext).IsSameReferenceAs(first);
+        view.ViewModel = second;
+        await Assert.That(window.DataContext).IsSameReferenceAs(second);
+        window.DataContext = null;
+        await Assert.That(view.ViewModel).IsNull();
+    }
+
     /// <summary>A test view model with a Name property.</summary>
     private sealed class VM : ReactiveObject;
 

--- a/src/tests/ReactiveUI.Avalonia.Tests/UseReactiveUIWithDIContainerTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/UseReactiveUIWithDIContainerTests.cs
@@ -4,6 +4,7 @@
 using Avalonia;
 using ReactiveUI.Builder;
 using Splat;
+using TUnit.Core.Executors;
 
 namespace ReactiveUI.Avalonia.Tests;
 
@@ -37,6 +38,64 @@ public class UseReactiveUIWithDIContainerTests
             static _ => { });
 
         await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    /// <summary>Verifies that deferred view registration executes through the platform setup callback.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task RegisterReactiveUIViews_AfterPlatformCallback_RegistersViews()
+    {
+        _ = new TestViewModel();
+        _ = new TestView();
+        var builder = AppBuilder.Configure<Application>()
+            .RegisterReactiveUIViews(typeof(UseReactiveUIWithDIContainerTests).Assembly);
+
+        builder.AfterPlatformServicesSetupCallback!(builder);
+
+        await Assert.That(AppLocator.Current.GetService<IViewFor<TestViewModel>>()).IsNotNull();
+    }
+
+    /// <summary>Verifies that the deferred DI-container callback executes the supplied factories.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    [TestExecutor<AutofacIsolatedTestExecutor>]
+    public async Task UseReactiveUIWithDIContainer_AfterPlatformSetupCallback_ConfiguresContainer()
+    {
+        ReactiveUIBuilder.ResetBuilderStateForTests();
+        var builder = AppBuilder.Configure<Application>();
+        var container = new object();
+        var factoryCalled = false;
+        var resolverFactoryCalled = false;
+        var configCalled = false;
+        var originalLocator = Locator.GetLocator();
+
+        try
+        {
+            _ = builder.UseReactiveUIWithDIContainer(
+                containerFactory: () =>
+                {
+                    factoryCalled = true;
+                    return container;
+                },
+                containerConfig: value => configCalled = ReferenceEquals(value, container),
+                dependencyResolverFactory: value =>
+                {
+                    resolverFactoryCalled = ReferenceEquals(value, container);
+                    return (IDependencyResolver)AppLocator.CurrentMutable;
+                },
+                static _ => { });
+
+            builder.AfterPlatformServicesSetupCallback!(builder);
+
+            await Assert.That(factoryCalled).IsTrue();
+            await Assert.That(resolverFactoryCalled).IsTrue();
+            await Assert.That(configCalled).IsTrue();
+        }
+        finally
+        {
+            Locator.SetLocator(originalLocator);
+            ReactiveUIBuilder.ResetBuilderStateForTests();
+        }
     }
 
     /// <summary>Verifies that the deferred callback validates a null container factory.</summary>
@@ -279,5 +338,22 @@ public class UseReactiveUIWithDIContainerTests
         public void RegisterLazySingleton<T>(Func<T?> valueFactory, string? contract)
             where T : class =>
             Register(() => valueFactory(), typeof(T), contract);
+    }
+
+    /// <summary>A view model used by deferred view registration tests.</summary>
+    private sealed class TestViewModel : ReactiveObject;
+
+    /// <summary>A view used by deferred view registration tests.</summary>
+    private sealed class TestView : IViewFor<TestViewModel>
+    {
+        /// <summary>Gets or sets the view model.</summary>
+        public TestViewModel? ViewModel { get; set; }
+
+        /// <inheritdoc/>
+        object? IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (TestViewModel?)value;
+        }
     }
 }

--- a/src/tests/ReactiveUI.Avalonia.Tests/ViewHostsNavigationTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/ViewHostsNavigationTests.cs
@@ -104,12 +104,19 @@ public class ViewHostsNavigationTests
     [Test]
     public async Task ViewModelViewHost_DetachBeforeAttach_DoesNotThrow()
     {
-        var source = GetPresentationSource();
+        var (window, source) = GetPresentationSource();
         var host = new TestableViewModelViewHost { DefaultContent = DefaultContentValue };
 
-        host.Detach(source);
+        try
+        {
+            host.Detach(source);
 
-        await Assert.That(host.Content).IsNull();
+            await Assert.That(host.Content).IsNull();
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     /// <summary>Verifies that ViewModelViewHost manual detach disposes an existing navigation subscription and tolerates a second detach.</summary>
@@ -117,14 +124,21 @@ public class ViewHostsNavigationTests
     [Test]
     public async Task ViewModelViewHost_AttachThenManualDetach_DisposesNavigationSubscription()
     {
-        var source = GetPresentationSource();
+        var (window, source) = GetPresentationSource();
         var host = new TestableViewModelViewHost { DefaultContent = DefaultContentValue };
 
-        host.Attach(source);
-        host.Detach(source);
-        host.Detach(source);
+        try
+        {
+            host.Attach(source);
+            host.Detach(source);
+            host.Detach(source);
 
-        await Assert.That(host.Content).IsEqualTo(DefaultContentValue);
+            await Assert.That(host.Content).IsEqualTo(DefaultContentValue);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     /// <summary>Verifies that ViewModelViewHost tolerates disposal when no navigation subscription exists.</summary>
@@ -274,6 +288,152 @@ public class ViewHostsNavigationTests
         }
     }
 
+    /// <summary>Verifies that RoutedViewHost displays navigation that happened before the host was attached.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task RoutedViewHost_AttachedSubscription_Navigates_WhenRouterAlreadyHasCurrentViewModel()
+    {
+        RegisterViews();
+        var screen = new ScreenImpl();
+        var vm = new VmA(screen);
+        _ = screen.Router.Navigate.Execute(vm).Subscribe();
+        var host = new TestableRoutedViewHost { DefaultContent = "def", Router = screen.Router };
+        var window = new Window { Content = host };
+
+        try
+        {
+            await Assert.That(screen.Router.NavigationStack.Count).IsEqualTo(1);
+
+            window.Show();
+
+            await Assert.That(host.Content).IsTypeOf<ViewA>();
+            await Assert.That(((IViewFor)host.Content!).ViewModel).IsSameReferenceAs(vm);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies that RoutedViewHost displays an already-current view model when the router is assigned after attachment.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task RoutedViewHost_AttachedSubscription_Navigates_WhenAlreadyNavigatedRouterIsAssigned()
+    {
+        RegisterViews();
+        var screen = new ScreenImpl();
+        var vm = new VmA(screen);
+        _ = screen.Router.Navigate.Execute(vm).Subscribe();
+        var host = new TestableRoutedViewHost { DefaultContent = "def" };
+        var window = new Window { Content = host };
+
+        try
+        {
+            window.Show();
+            host.Router = screen.Router;
+
+            await Assert.That(screen.Router.NavigationStack.Count).IsEqualTo(1);
+            await Assert.That(host.Content).IsTypeOf<ViewA>();
+            await Assert.That(((IViewFor)host.Content!).ViewModel).IsSameReferenceAs(vm);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies that RoutedViewHost ignores navigation from a router after another router is assigned.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task RoutedViewHost_AttachedSubscription_IgnoresPreviousRouterAfterReplacement()
+    {
+        var firstScreen = new ScreenImpl();
+        var secondScreen = new ScreenImpl();
+        var firstVm = new VmA(firstScreen);
+        var secondVm = new VmA(secondScreen);
+        var view = new ViewA();
+        var host = new TestableRoutedViewHost { DefaultContent = "def", Router = firstScreen.Router, ViewLocator = new StaticViewLocator(view) };
+        var window = new Window { Content = host };
+
+        try
+        {
+            window.Show();
+            _ = firstScreen.Router.Navigate.Execute(firstVm).Subscribe();
+            await Assert.That(view.ViewModel).IsSameReferenceAs(firstVm);
+
+            host.Router = secondScreen.Router;
+            _ = secondScreen.Router.Navigate.Execute(secondVm).Subscribe();
+            await Assert.That(view.ViewModel).IsSameReferenceAs(secondVm);
+
+            _ = firstScreen.Router.Navigate.Execute(new VmA(firstScreen)).Subscribe();
+            await Assert.That(view.ViewModel).IsSameReferenceAs(secondVm);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies that RoutedViewHost ignores router navigation after the router is cleared.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task RoutedViewHost_AttachedSubscription_IgnoresPreviousRouterAfterRouterCleared()
+    {
+        var screen = new ScreenImpl();
+        var vm = new VmA(screen);
+        var view = new ViewA();
+        var host = new TestableRoutedViewHost { DefaultContent = "def", Router = screen.Router, ViewLocator = new StaticViewLocator(view) };
+        var window = new Window { Content = host };
+
+        try
+        {
+            window.Show();
+            _ = screen.Router.Navigate.Execute(vm).Subscribe();
+            await Assert.That(view.ViewModel).IsSameReferenceAs(vm);
+
+            host.Router = null;
+            _ = screen.Router.Navigate.Execute(new VmA(screen)).Subscribe();
+
+            await Assert.That(host.Content).IsEqualTo("def");
+            await Assert.That(view.ViewModel).IsSameReferenceAs(vm);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>Verifies that RoutedViewHost ignores navigation while detached and catches up when reattached.</summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Test]
+    public async Task RoutedViewHost_AttachedSubscription_CatchesUpToCurrentViewModelAfterReattach()
+    {
+        var screen = new ScreenImpl();
+        var firstVm = new VmA(screen);
+        var secondVm = new VmA(screen);
+        var view = new ViewA();
+        var host = new TestableRoutedViewHost { DefaultContent = "def", Router = screen.Router, ViewLocator = new StaticViewLocator(view) };
+        var window = new Window { Content = host };
+
+        try
+        {
+            window.Show();
+            _ = screen.Router.Navigate.Execute(firstVm).Subscribe();
+            await Assert.That(view.ViewModel).IsSameReferenceAs(firstVm);
+
+            window.Content = null;
+            _ = screen.Router.Navigate.Execute(secondVm).Subscribe();
+            await Assert.That(view.ViewModel).IsSameReferenceAs(firstVm);
+
+            window.Content = host;
+            await Assert.That(view.ViewModel).IsSameReferenceAs(secondVm);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
     /// <summary>Verifies that RoutedViewHost falls back when the router is removed after attachment.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
@@ -301,12 +461,19 @@ public class ViewHostsNavigationTests
     [Test]
     public async Task RoutedViewHost_DetachBeforeAttach_DoesNotThrow()
     {
-        var source = GetPresentationSource();
+        var (window, source) = GetPresentationSource();
         var host = new TestableRoutedViewHost { DefaultContent = "def" };
 
-        host.Detach(source);
+        try
+        {
+            host.Detach(source);
 
-        await Assert.That(host.Content).IsNull();
+            await Assert.That(host.Content).IsNull();
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     /// <summary>Verifies that RoutedViewHost manual detach disposes an existing navigation subscription and tolerates a second detach.</summary>
@@ -314,14 +481,21 @@ public class ViewHostsNavigationTests
     [Test]
     public async Task RoutedViewHost_AttachThenManualDetach_DisposesNavigationSubscription()
     {
-        var source = GetPresentationSource();
+        var (window, source) = GetPresentationSource();
         var host = new TestableRoutedViewHost { DefaultContent = "def", Router = new() };
 
-        host.Attach(source);
-        host.Detach(source);
-        host.Detach(source);
+        try
+        {
+            host.Attach(source);
+            host.Detach(source);
+            host.Detach(source);
 
-        await Assert.That(host.Content).IsEqualTo("def");
+            await Assert.That(host.Content).IsEqualTo("def");
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     /// <summary>Verifies that RoutedViewHost tolerates disposal when no navigation subscription exists.</summary>
@@ -410,22 +584,15 @@ public class ViewHostsNavigationTests
 
     /// <summary>Gets a real presentation source from a headless window.</summary>
     /// <returns>The presentation source.</returns>
-    private static IPresentationSource GetPresentationSource()
+    private static (Window Window, IPresentationSource Source) GetPresentationSource()
     {
         IPresentationSource? source = null;
         var control = new Control();
         control.AttachedToVisualTree += (_, args) => source = args.PresentationSource;
         var window = new Window { Content = control };
 
-        try
-        {
-            window.Show();
-            return source!;
-        }
-        finally
-        {
-            window.Close();
-        }
+        window.Show();
+        return (window, source!);
     }
 
     /// <summary>A testable ViewModelViewHost that exposes protected members.</summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature, bug fix, test coverage, documentation, and dependency maintenance.

## What is the new behavior?

- Adds a lean `ReactiveUI.Primitives` Avalonia showcase with routed navigation, bindings, commands, interactions, activation, live process metrics, and persisted session state.
- Fixes #194: `RoutedViewHost` presents the current route when navigation occurs before attachment, follows router replacement, and catches up after reattachment.
- Fixes #122: a nullable command clears a valid command source and safely returns an empty binding disposable, so public `BindCommand` transitions work correctly.
- Makes shutdown persistence safe when no subscriber is registered and removes the controlled-lifetime handler on disposal.
- Expands core and DI package coverage, and corrects headless test execution so asynchronous test work is awaited.

## What is the current behavior?

Before this change, a route already present in `NavigationStack` could leave `RoutedViewHost` blank, and nullable command updates could be treated as a failed binding. The repository had no end-to-end Avalonia showcase for the lean package graph.

## Checklist

- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

## Additional information

Validation completed from `src`:

- `dotnet build ReactiveUI.Avalonia.slnx -c Release -warnaserror --no-incremental` — 0 warnings, 0 errors.
- `dotnet test --solution ReactiveUI.Avalonia.slnx -c Release --coverage --coverage-output-format cobertura --results-directory D:/Projects/Github/reactiveui/Avalonia/artifacts/coverage/verified-final --report-trx --progress off --disable-logo` — 1,041 passed, 0 failed, 0 skipped.
- The coverage report confirms 100% line and branch coverage for all ten shipping package projects.
- All ten packages packed successfully with `-warnaserror`, each containing net8.0, net9.0, net10.0, and net11.0 assemblies.
- The example was exercised in the Windows desktop runtime: navigation, live metrics, bindings, command success/failure, interactions, and session restore all passed.

The example is intentionally a normal untrimmed desktop application so it can demonstrate expression-based ReactiveUI binding and activation. Shipping packages retain their declared trimming and AOT analysis.
