### PR TITLE
build: add public API baselines and CI code scanning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ root = true
 # Default settings
 #############################################
 [*]
+charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 indent_style = space
@@ -695,7 +696,7 @@ dotnet_diagnostic.SYSLIB1104.severity = error # Configuration binding source gen
 # EnforceCodeStyleInBuild=true (set in Directory.Build.props) promotes these
 # IDE rules into `dotnet build` so they fire at compile time, not just in the
 # IDE. We enable the ones that are unambiguous wins and skip the rules that
-# conflict with an existing convention (SA1101, SA1200, SA1206, SA1400, SA1633,
+# conflict with an existing convention (SST1117, SST1200, SST1206, SST1400, SST1633,
 # etc.) so we don't double-report.
 
 # Bug catchers — always error.
@@ -728,10 +729,10 @@ dotnet_diagnostic.IDE0221.severity = none # Add explicit cast — covered by SST
 dotnet_diagnostic.IDE0250.severity = none # Make struct 'readonly' — covered by PSH1014
 dotnet_diagnostic.IDE0260.severity = none # Use pattern matching — covered by SST2006/SST2231
 
-# Disabled — conflict with an existing SA/CA rule or project convention.
+# Disabled — conflict with an existing rule or project convention.
 dotnet_diagnostic.IDE0007.severity = none # Use var — we don't force var in either direction
 dotnet_diagnostic.IDE0008.severity = none # Use explicit type — we don't force var in either direction
-dotnet_diagnostic.IDE0009.severity = none # Member access should be qualified — SA1101 = none
+dotnet_diagnostic.IDE0009.severity = none # Member access should be qualified — SST1117 owns the qualification style
 dotnet_diagnostic.IDE0021.severity = none # Use expression body for constructors — covered by SST2276 (opt-in)
 dotnet_diagnostic.IDE0022.severity = none # Use expression body for methods — covered by SST2275
 dotnet_diagnostic.IDE0023.severity = none # Use expression body for conversion operators — covered by SST2278 (opt-in)
@@ -739,7 +740,7 @@ dotnet_diagnostic.IDE0024.severity = none # Use expression body for operators �
 dotnet_diagnostic.IDE0025.severity = none # Use expression body for properties — covered by SST2279
 dotnet_diagnostic.IDE0026.severity = none # Use expression body for indexers — covered by SST2280
 dotnet_diagnostic.IDE0048.severity = none # Add parentheses for clarity — preference not enforced
-dotnet_diagnostic.IDE0055.severity = none # Formatting — StyleCop SA rules own formatting
+dotnet_diagnostic.IDE0055.severity = none # Formatting — the spacing and layout rules own formatting
 dotnet_diagnostic.IDE0058.severity = none # Remove unnecessary expression value — covered by SST2221
 dotnet_diagnostic.IDE0060.severity = none # Remove unused parameter — CA1801 handles (with api_surface config)
 dotnet_diagnostic.IDE0061.severity = none # Use expression body for local function — covered by SST2281
@@ -752,9 +753,9 @@ dotnet_diagnostic.IDE0300.severity = none # Use collection expression for array 
 dotnet_diagnostic.IDE0306.severity = none # Use collection expression for new — covered by SST2101
 dotnet_diagnostic.IDE0320.severity = none # Make anonymous function static — covered by PSH1000
 dotnet_diagnostic.IDE0050.severity = none # Convert anonymous type to tuple — covered by SST2224
-dotnet_diagnostic.IDE0310.severity = none # Convert lambda expression to method group — handled by RCS1207
+dotnet_diagnostic.IDE0310.severity = none # Convert lambda expression to method group — a lambda keeps the delegate target explicit
 dotnet_diagnostic.IDE0360.severity = none # Simplify property accessor — covered by SST2219
-dotnet_diagnostic.IDE0370.severity = none # Remove unnecessary suppression (null-forgiving operator) — disabled for the same reason as RCS1249: multi-TFM nullability annotations can differ per platform
+dotnet_diagnostic.IDE0370.severity = none # Remove unnecessary suppression (null-forgiving operator) — multi-TFM nullability annotations can differ per platform
 
 # Language and unnecessary code rules.
 dotnet_diagnostic.IDE0001.severity = none # Simplify name
@@ -821,276 +822,11 @@ dotnet_diagnostic.IDE0380.severity = none # Remove unnecessary unsafe modifier
 dotnet_diagnostic.IDE1005.severity = none # Use conditional delegate call
 
 # Naming and miscellaneous
-# Naming conventions — SA1300 family already enforces PascalCase / interface
-# prefix / field casing (with our _underscore convention on SA1306/1309/1311
-# deliberately disabled). Leaving IDE1006 off because configuring
-# `dotnet_naming_rule.*` would duplicate what SA already enforces and could
-# conflict with the _underscore convention.
-dotnet_diagnostic.IDE1006.severity = none # Naming rule violation — SA1300 family handles naming
+# The SST1300 family enforces PascalCase, the interface prefix and field casing, with the
+# _underscore convention keeping SST1306/1309/1311 off. Configuring `dotnet_naming_rule.*` would
+# duplicate that and clash with the _underscore convention, so IDE1006 stays off.
+dotnet_diagnostic.IDE1006.severity = none # Naming rule violation — SST1300 family handles naming
 dotnet_diagnostic.IDE3000.severity = none # Disabled per project convention — not enforced
-
-###################
-# Roslynator.CSharp.Analyzers (RCS)
-###################
-# Code simplification
-dotnet_diagnostic.RCS1001.severity = none # Add braces (when expression spans over multiple lines) — covered by SST1519
-dotnet_diagnostic.RCS1003.severity = none # Add braces to if-else (when expression spans over multiple lines) — covered by SST1519
-dotnet_diagnostic.RCS1005.severity = error # Simplify nested using statement
-dotnet_diagnostic.RCS1006.severity = none # Merge 'else' with nested 'if' — covered by SST1465
-dotnet_diagnostic.RCS1007.severity = error # Add braces
-dotnet_diagnostic.RCS1031.severity = none # Remove unnecessary braces in switch section -- we don't mind braces in switch statements
-dotnet_diagnostic.RCS1032.severity = error # Remove redundant parentheses
-dotnet_diagnostic.RCS1033.severity = none # Remove redundant boolean literal — covered by SST1143
-dotnet_diagnostic.RCS1039.severity = none # Remove argument list from attribute — covered by SST1411
-dotnet_diagnostic.RCS1040.severity = none # Remove empty statement — covered by SST1180
-dotnet_diagnostic.RCS1042.severity = none # Remove enum default underlying type — covered by SST1177
-dotnet_diagnostic.RCS1043.severity = error # Remove 'partial' modifier from type with a single part
-dotnet_diagnostic.RCS1049.severity = none # Simplify boolean comparison — covered by SST1143
-dotnet_diagnostic.RCS1058.severity = none # Use compound assignment — covered by SST1185
-dotnet_diagnostic.RCS1061.severity = none # Merge 'if' with nested 'if' — covered by SST2013
-dotnet_diagnostic.RCS1068.severity = none # Simplify logical negation — covered by SST1172/SST2006
-dotnet_diagnostic.RCS1069.severity = none # Remove unnecessary case label — covered by SST1466
-dotnet_diagnostic.RCS1070.severity = none # Remove redundant default switch section — covered by SST1179
-dotnet_diagnostic.RCS1071.severity = none # Remove redundant base constructor call — covered by SST1178
-dotnet_diagnostic.RCS1072.severity = none # Remove empty namespace declaration — covered by SST1435
-dotnet_diagnostic.RCS1073.severity = none # Convert 'if' to 'return' statement — covered by SST1197
-dotnet_diagnostic.RCS1074.severity = none # Remove redundant constructor — covered by SST1433
-dotnet_diagnostic.RCS1078.severity = none # Use "" or 'string.Empty' — conflicts with SST1122, which owns the string.Empty direction
-dotnet_diagnostic.RCS1084.severity = none # Use coalesce expression instead of conditional expression — covered by SST1195
-dotnet_diagnostic.RCS1085.severity = none # Use auto-implemented property — covered by SST1420
-dotnet_diagnostic.RCS1089.severity = error # Use --/++ operator instead of assignment
-dotnet_diagnostic.RCS1097.severity = error # Remove redundant 'ToString' call
-dotnet_diagnostic.RCS1103.severity = error # Convert 'if' to assignment
-dotnet_diagnostic.RCS1104.severity = none # Simplify conditional expression — covered by SST1182
-dotnet_diagnostic.RCS1105.severity = error # Unnecessary interpolation
-dotnet_diagnostic.RCS1106.severity = none # Remove empty destructor — covered by PSH1002
-dotnet_diagnostic.RCS1107.severity = none # Remove redundant 'ToCharArray' call — covered by PSH1217
-dotnet_diagnostic.RCS1114.severity = error # Remove redundant delegate creation
-dotnet_diagnostic.RCS1124.severity = error # Inline local variable
-dotnet_diagnostic.RCS1126.severity = error # Add braces to if-else
-dotnet_diagnostic.RCS1128.severity = error # Use coalesce expression
-dotnet_diagnostic.RCS1129.severity = none # Remove redundant field initialization — covered by SST1176
-dotnet_diagnostic.RCS1132.severity = none # Remove redundant overriding member — covered by SST1181
-dotnet_diagnostic.RCS1133.severity = error # Remove redundant Dispose/Close call
-dotnet_diagnostic.RCS1134.severity = none # Remove redundant statement — covered by SST1174
-dotnet_diagnostic.RCS1143.severity = error # Simplify coalesce expression
-dotnet_diagnostic.RCS1145.severity = error # Remove redundant 'as' operator
-dotnet_diagnostic.RCS1146.severity = error # Use conditional access
-dotnet_diagnostic.RCS1151.severity = none # Remove redundant cast — covered by SST1175
-dotnet_diagnostic.RCS1171.severity = error # Simplify lazy initialization
-dotnet_diagnostic.RCS1173.severity = error # Use coalesce expression instead of 'if'
-dotnet_diagnostic.RCS1174.severity = none # Remove redundant async/await — covered by PSH1311
-dotnet_diagnostic.RCS1179.severity = error # Unnecessary assignment
-dotnet_diagnostic.RCS1180.severity = error # Inline lazy initialization
-dotnet_diagnostic.RCS1188.severity = none # Remove redundant auto-property initialization — covered by SST1176
-dotnet_diagnostic.RCS1192.severity = none # Unnecessary usage of verbatim string literal — covered by SST1184
-dotnet_diagnostic.RCS1199.severity = error # Unnecessary null check
-dotnet_diagnostic.RCS1206.severity = error # Use conditional access instead of conditional expression
-dotnet_diagnostic.RCS1207.severity = none # Use anonymous function or method group — conflicts with SST2239, which owns the method-group direction
-dotnet_diagnostic.RCS1211.severity = none # Remove unnecessary 'else' — covered by SST1464
-dotnet_diagnostic.RCS1212.severity = error # Remove redundant assignment
-dotnet_diagnostic.RCS1214.severity = none # Unnecessary interpolated string — covered by SST1183
-dotnet_diagnostic.RCS1216.severity = error # Unnecessary unsafe context
-dotnet_diagnostic.RCS1217.severity = none # Convert interpolated string to concatenation — reverses SST2249, which owns the concatenation-to-interpolation direction
-dotnet_diagnostic.RCS1218.severity = error # Simplify code branching
-dotnet_diagnostic.RCS1220.severity = none # Use pattern matching instead of combination of 'is' and cast — covered by SST2007
-dotnet_diagnostic.RCS1221.severity = error # Use pattern matching instead of combination of 'as' and null check
-dotnet_diagnostic.RCS1238.severity = none # Avoid nested ?: operators — covered by SST1147
-dotnet_diagnostic.RCS1244.severity = none # Simplify 'default' expression — covered by SST1188
-dotnet_diagnostic.RCS1249.severity = none # Unnecessary null-forgiving operator — disabled because multi-TFM nullability annotations can differ per platform, leading to false positives
-dotnet_diagnostic.RCS1251.severity = error # Remove unnecessary braces from record declaration
-dotnet_diagnostic.RCS1259.severity = error # Remove empty syntax (replaces RCS1066)
-dotnet_diagnostic.RCS1262.severity = error # Unnecessary raw string literal
-dotnet_diagnostic.RCS1265.severity = none # Remove redundant catch block — covered by SST1470
-dotnet_diagnostic.RCS1268.severity = error # Simplify numeric comparison
-
-# Code quality
-dotnet_diagnostic.RCS1013.severity = none # Use predefined type — covered by SST1121
-dotnet_diagnostic.RCS1014.severity = error # Use explicitly/implicitly typed array
-dotnet_diagnostic.RCS1015.severity = error # Use nameof operator
-dotnet_diagnostic.RCS1016.severity = none # Use block body or expression body — conflicts with SST2219, which owns the expression-bodied accessor direction
-dotnet_diagnostic.RCS1020.severity = none # Covered by SST2234 (canonical)
-dotnet_diagnostic.RCS1021.severity = error # Convert lambda expression body to expression body
-dotnet_diagnostic.RCS1044.severity = none # Remove original exception from throw statement — covered by SST1430
-dotnet_diagnostic.RCS1046.severity = none # Asynchronous method name should end with 'Async' — TUnit test method naming convention doesn't follow the Async suffix — covered by SST1317
-dotnet_diagnostic.RCS1047.severity = error # Non-asynchronous method name should not end with 'Async'
-dotnet_diagnostic.RCS1048.severity = none # Use lambda expression instead of anonymous method — covered by SST1130
-dotnet_diagnostic.RCS1050.severity = error # Include/omit parentheses when creating new object
-dotnet_diagnostic.RCS1051.severity = none # Add/remove parentheses from condition in conditional operator — conflicts with SST1459, which owns the non-grouping-parenthesis removal direction
-dotnet_diagnostic.RCS1056.severity = none # Avoid usage of using alias directive - used to avoid conflicts
-dotnet_diagnostic.RCS1059.severity = none # Avoid locking on publicly accessible instance — covered by SST1901
-dotnet_diagnostic.RCS1075.severity = none # Avoid empty catch clause that catches System.Exception — covered by SST1429
-dotnet_diagnostic.RCS1079.severity = error # Throwing of new NotImplementedException
-dotnet_diagnostic.RCS1081.severity = error # Split variable declaration
-dotnet_diagnostic.RCS1093.severity = error # File contains no code
-dotnet_diagnostic.RCS1094.severity = none # Declare using directive on top level — covered by SST1200
-dotnet_diagnostic.RCS1096.severity = none # Use 'HasFlag' method or bitwise operator — covered by PSH1016
-dotnet_diagnostic.RCS1098.severity = none # Constant values should be placed on right side of comparisons — covered by SST1186
-dotnet_diagnostic.RCS1099.severity = none # Default label should be the last label in a switch section — covered by SST1466
-dotnet_diagnostic.RCS1102.severity = none # Make class static — covered by SST1432
-dotnet_diagnostic.RCS1108.severity = error # Add 'static' modifier to all partial class declarations
-dotnet_diagnostic.RCS1111.severity = error # Add braces to switch section with multiple statements
-dotnet_diagnostic.RCS1113.severity = error # Use 'string.IsNullOrEmpty' method
-dotnet_diagnostic.RCS1118.severity = none # Mark local variable as const — covered by PSH1402
-dotnet_diagnostic.RCS1123.severity = none # Add parentheses when necessary — covered by SST1407
-dotnet_diagnostic.RCS1130.severity = none # Bitwise operation on enum without Flags attribute — covered by SST2458
-dotnet_diagnostic.RCS1135.severity = error # Declare enum member with zero value (when enum has FlagsAttribute)
-dotnet_diagnostic.RCS1136.severity = none # Merge switch sections with equivalent content — covered by SST2414
-dotnet_diagnostic.RCS1154.severity = error # Sort enum members
-dotnet_diagnostic.RCS1155.severity = none # Use StringComparison when comparing strings — covered by PSH1207
-dotnet_diagnostic.RCS1156.severity = none # Use string.Length instead of comparison with empty string — covered by PSH1204
-dotnet_diagnostic.RCS1157.severity = none # Composite enum value contains undefined flag — covered by SST2303
-dotnet_diagnostic.RCS1159.severity = error # Use EventHandler<T>
-dotnet_diagnostic.RCS1160.severity = none # Abstract type should not have public constructors — covered by SST1428
-dotnet_diagnostic.RCS1161.severity = none # Enum should declare explicit values - do not need explicit values
-dotnet_diagnostic.RCS1162.severity = none # Avoid chain of assignments — covered by SST1187
-dotnet_diagnostic.RCS1166.severity = none # Value type object is never equal to null — covered by SST1469
-dotnet_diagnostic.RCS1168.severity = none # Parameter name differs from base name — covered by SST1318
-dotnet_diagnostic.RCS1169.severity = error # Make field read-only
-dotnet_diagnostic.RCS1170.severity = error # Use read-only auto-implemented property
-dotnet_diagnostic.RCS1172.severity = none # Use 'is' operator instead of 'as' operator — covered by SST2005
-dotnet_diagnostic.RCS1187.severity = none # Use constant instead of field — covered by PSH1402
-dotnet_diagnostic.RCS1191.severity = error # Declare enum value as combination of names
-dotnet_diagnostic.RCS1193.severity = none # Overriding member should not change 'params' modifier — covered by SST2426
-dotnet_diagnostic.RCS1196.severity = error # Call extension method as instance method
-dotnet_diagnostic.RCS1200.severity = none # Call 'Enumerable.ThenBy' instead of 'Enumerable.OrderBy' — covered by PSH1108
-dotnet_diagnostic.RCS1201.severity = error # Use method chaining
-dotnet_diagnostic.RCS1202.severity = error # Avoid NullReferenceException
-dotnet_diagnostic.RCS1204.severity = error # Use EventArgs.Empty
-dotnet_diagnostic.RCS1205.severity = error # Order named arguments according to the order of parameters
-dotnet_diagnostic.RCS1208.severity = error # Reduce 'if' nesting
-dotnet_diagnostic.RCS1209.severity = error # Order type parameter constraints
-dotnet_diagnostic.RCS1210.severity = none # Return completed task instead of returning null — covered by PSH1312
-dotnet_diagnostic.RCS1215.severity = error # Expression is always equal to true/false
-dotnet_diagnostic.RCS1222.severity = error # Merge preprocessor directives
-dotnet_diagnostic.RCS1223.severity = suggestion # Mark publicly visible type with DebuggerDisplay attribute — only data types benefit; the rule is too broad to be an error
-dotnet_diagnostic.RCS1224.severity = error # Make method an extension method
-dotnet_diagnostic.RCS1225.severity = error # Make class sealed
-dotnet_diagnostic.RCS1227.severity = none # Validate arguments correctly — covered by SST2404
-dotnet_diagnostic.RCS1229.severity = error # Use async/await when necessary
-dotnet_diagnostic.RCS1231.severity = none # Make parameter ref read-only — covered by PSH1007
-dotnet_diagnostic.RCS1233.severity = none # Use short-circuiting operator — covered by SST1468
-dotnet_diagnostic.RCS1234.severity = error # Duplicate enum value
-dotnet_diagnostic.RCS1239.severity = error # Use 'for' statement instead of 'while' statement
-dotnet_diagnostic.RCS1240.severity = error # Operator is unnecessary
-dotnet_diagnostic.RCS1242.severity = none # Do not pass non-read-only struct by read-only reference — covered by PSH1003
-dotnet_diagnostic.RCS1243.severity = none # Duplicate word in a comment — covered by SST1658 (documentation comments)
-dotnet_diagnostic.RCS1247.severity = error # Fix documentation comment tag
-dotnet_diagnostic.RCS1248.severity = none # Normalize null check — conflicts with SST1149, which owns the 'is null' pattern direction
-dotnet_diagnostic.RCS1250.severity = none # Use implicit/explicit object creation — conflicts with SST2202, which owns the implicit-target-type direction
-dotnet_diagnostic.RCS1252.severity = error # Normalize usage of infinite loop
-dotnet_diagnostic.RCS1254.severity = error # Normalize format of enum flag value
-dotnet_diagnostic.RCS1255.severity = none # Simplify argument null check — conflicts with our ArgumentExceptionHelper helper pattern
-dotnet_diagnostic.RCS1257.severity = error # Use enum field explicitly
-dotnet_diagnostic.RCS1258.severity = error # Unnecessary enum flag
-dotnet_diagnostic.RCS1260.severity = none # Add/remove trailing comma — conflicts with SST1413, which owns the trailing-comma direction
-dotnet_diagnostic.RCS1261.severity = none # Resource can be disposed asynchronously — covered by PSH1310
-dotnet_diagnostic.RCS1264.severity = error # Use 'var' or explicit type (replaces RCS1010, RCS1176, RCS1177)
-dotnet_diagnostic.RCS1266.severity = none # Use raw string literal — covered by SST2243
-dotnet_diagnostic.RCS1267.severity = error # Use string interpolation instead of 'string.Concat'
-
-# Performance
-dotnet_diagnostic.RCS1077.severity = none # Covered by the PSH1101-PSH1111 family (canonical)
-dotnet_diagnostic.RCS1080.severity = none # Covered by PSH1106 (canonical)
-dotnet_diagnostic.RCS1112.severity = none # Combine 'Enumerable.Where' method chain — covered by PSH1109
-dotnet_diagnostic.RCS1186.severity = error # Use Regex instance instead of static method
-dotnet_diagnostic.RCS1190.severity = none # Join string expressions — conflicts with SST2470, which reports the fused-literal seam this would create
-dotnet_diagnostic.RCS1195.severity = error # Use ^ operator
-dotnet_diagnostic.RCS1197.severity = none # Optimize StringBuilder.Append/AppendLine call — covered by PSH1203/PSH1214
-dotnet_diagnostic.RCS1198.severity = none # Avoid unnecessary boxing of value type — boxing is unavoidable bridging Rx and IEnumerable<object>
-dotnet_diagnostic.RCS1230.severity = none # Unnecessary explicit use of enumerator — covered by SST1467
-dotnet_diagnostic.RCS1235.severity = error # Optimize method call
-dotnet_diagnostic.RCS1236.severity = none # Use exception filter — covered by SST2009
-dotnet_diagnostic.RCS1246.severity = none # Use element access — covered by PSH1106
-
-# Maintainability
-dotnet_diagnostic.RCS1158.severity = none # Static member in generic type should use a type parameter — common factory pattern — covered by SST1431
-dotnet_diagnostic.RCS1163.severity = none # Unused parameter — interface implementations and Rx selectors often have unused parameters
-dotnet_diagnostic.RCS1164.severity = none # Unused type parameter - DUPLICATE IDE0060 (UnusedParameter analyzer 210ms; IDE0060 bundled at lower cost)
-dotnet_diagnostic.RCS1165.severity = none # Unconstrained type parameter checked for null - we validate all parameters for non-nullable enabled platforms
-dotnet_diagnostic.RCS1182.severity = none # Remove redundant base interface — covered by SST1177
-dotnet_diagnostic.RCS1213.severity = none # Remove unused member declaration - DUPLICATE IDE0051 (slower: 230ms vs 75ms)
-dotnet_diagnostic.RCS1241.severity = error # Implement non-generic counterpart
-dotnet_diagnostic.RCS1256.severity = none # Invalid argument null check — conflicts with our ArgumentExceptionHelper helper pattern
-
-# Documentation
-dotnet_diagnostic.RCS1181.severity = error # Convert comment to documentation comment
-dotnet_diagnostic.RCS1189.severity = error # Add or remove region name
-dotnet_diagnostic.RCS1226.severity = none # Add paragraph to documentation comment — &lt;para&gt; wrapping is subjective and adds noise
-dotnet_diagnostic.RCS1228.severity = error # Unused element in a documentation comment
-dotnet_diagnostic.RCS1232.severity = error # Order elements in documentation comment
-dotnet_diagnostic.RCS1253.severity = error # Format documentation comment summary
-dotnet_diagnostic.RCS1263.severity = none # Invalid reference in a documentation comment
-
-# Disabled
-dotnet_diagnostic.RCS1018.severity = none # Add/remove accessibility modifiers — covered by SA1400
-dotnet_diagnostic.RCS1019.severity = none # Order modifiers — covered by SA1206 / SA1208
-dotnet_diagnostic.RCS1037.severity = none # Remove trailing white-space — covered by SA1028
-dotnet_diagnostic.RCS1052.severity = none # Declare each attribute separately — covered by SA1133
-dotnet_diagnostic.RCS1055.severity = none # Unnecessary semicolon at the end of declaration — covered by SA1106
-dotnet_diagnostic.RCS1060.severity = none # Declare each type in separate file — covered by SA1402
-dotnet_diagnostic.RCS1090.severity = none # Add/remove 'ConfigureAwait(false)' call — covered by CA2007 (also disabled)
-dotnet_diagnostic.RCS1110.severity = none # Declare type inside namespace — covered by CA1050
-dotnet_diagnostic.RCS1138.severity = none # Add summary to documentation comment — covered by SA1600
-dotnet_diagnostic.RCS1139.severity = none # Add summary element to documentation comment — covered by SA1604
-dotnet_diagnostic.RCS1140.severity = none # Add exception to documentation comment — covered by SA1614
-dotnet_diagnostic.RCS1141.severity = none # Add 'param' element to documentation comment — covered by SA1611
-dotnet_diagnostic.RCS1142.severity = none # Add 'typeparam' element to documentation comment — covered by SA1618
-dotnet_diagnostic.RCS1175.severity = none # Unused 'this' parameter — covered by CA1822
-dotnet_diagnostic.RCS1194.severity = none # Implement exception constructors — covered by CA1032
-dotnet_diagnostic.RCS1203.severity = none # Use AttributeUsageAttribute — covered by CA1018
-
-# Formatting
-dotnet_diagnostic.RCS0001.severity = none # Add blank line after embedded statement — covered by StyleCop layout rules
-dotnet_diagnostic.RCS0002.severity = none # Add blank line after #region — covered by StyleCop SA1517 family
-dotnet_diagnostic.RCS0003.severity = none # Add blank line after using directive list — covered by SA1516
-dotnet_diagnostic.RCS0005.severity = none # Add blank line before #endregion — covered by StyleCop layout rules
-dotnet_diagnostic.RCS0006.severity = none # Add blank line before using directive list — covered by SA1517
-dotnet_diagnostic.RCS0007.severity = none # Add blank line between accessors — covered by SA1513
-dotnet_diagnostic.RCS0008.severity = none # Add blank line between closing brace and next statement — covered by SA1513
-dotnet_diagnostic.RCS0009.severity = none # Add blank line between declaration and documentation comment — covered by SA1514
-dotnet_diagnostic.RCS0010.severity = none # Add blank line between declarations — covered by SA1516
-dotnet_diagnostic.RCS0011.severity = none # Add/remove blank line between single-line accessors — StyleCop already governs this
-dotnet_diagnostic.RCS0012.severity = none # Add blank line between single-line declarations — covered by SA1516
-dotnet_diagnostic.RCS0013.severity = none # Add blank line between single-line declarations of different kind — covered by SA1516
-dotnet_diagnostic.RCS0015.severity = none # Add/remove blank line between using directives — covered by SA1209 / SA1210
-dotnet_diagnostic.RCS0016.severity = none # Put attribute list on its own line — StyleCop SA1133 governs attribute lists
-dotnet_diagnostic.RCS0020.severity = none # Format accessor's braces — covered by SA1500
-dotnet_diagnostic.RCS0021.severity = none # Format block's braces — covered by SA1500
-dotnet_diagnostic.RCS0023.severity = none # Format type declaration's braces — covered by SA1500
-dotnet_diagnostic.RCS0024.severity = none # Add new line after switch label — covered by SA1003
-dotnet_diagnostic.RCS0025.severity = none # Put full accessor on its own line — covered by SA1502
-dotnet_diagnostic.RCS0027.severity = none # Place new line after/before binary operator — StyleCop wrapping rules cover this
-dotnet_diagnostic.RCS0028.severity = none # Place new line after/before '?:' operator — StyleCop wrapping rules cover this
-dotnet_diagnostic.RCS0029.severity = none # Put constructor initializer on its own line — StyleCop wrapping rules cover this
-dotnet_diagnostic.RCS0030.severity = none # Put embedded statement on its own line — covered by SA1503
-dotnet_diagnostic.RCS0031.severity = none # Put enum member on its own line — covered by SA1136
-dotnet_diagnostic.RCS0032.severity = none # Place new line after/before arrow token — StyleCop wrapping rules cover this
-dotnet_diagnostic.RCS0033.severity = none # Put statement on its own line — covered by SA1505 family
-dotnet_diagnostic.RCS0034.severity = none # Put type parameter constraint on its own line — StyleCop wrapping rules cover this
-dotnet_diagnostic.RCS0036.severity = none # Remove blank line between single-line declarations of same kind — covered by SA1516
-dotnet_diagnostic.RCS0039.severity = none # Remove new line before base list — StyleCop wrapping rules cover this
-dotnet_diagnostic.RCS0041.severity = none # Remove new line between 'if' keyword and 'else' keyword — StyleCop layout rules cover this
-dotnet_diagnostic.RCS0042.severity = none # Put auto-accessors on a single line — formatting preference, not enforced
-dotnet_diagnostic.RCS0044.severity = none # Use carriage return + linefeed as new line — handled by .gitattributes / editorconfig end_of_line
-dotnet_diagnostic.RCS0045.severity = none # Use linefeed as new line — handled by .gitattributes / editorconfig end_of_line
-dotnet_diagnostic.RCS0046.severity = none # Use spaces instead of tab — handled by editorconfig indent_style
-dotnet_diagnostic.RCS0048.severity = none # Put initializer on a single line — formatting preference, not enforced
-dotnet_diagnostic.RCS0049.severity = none # Add blank line after top comment — covered by SA1517
-dotnet_diagnostic.RCS0050.severity = none # Add blank line before top declaration — covered by SA1517
-dotnet_diagnostic.RCS0051.severity = none # Add/remove new line before 'while' in 'do' statement — formatting preference
-dotnet_diagnostic.RCS0052.severity = none # Place new line after/before equals token — StyleCop wrapping rules cover this
-dotnet_diagnostic.RCS0053.severity = none # Fix formatting of a list — formatting preference
-dotnet_diagnostic.RCS0054.severity = none # Fix formatting of a call chain — formatting preference
-dotnet_diagnostic.RCS0055.severity = none # Fix formatting of a binary expression chain — formatting preference
-dotnet_diagnostic.RCS0056.severity = none # A line is too long — line-length not enforced
-dotnet_diagnostic.RCS0057.severity = none # Normalize whitespace at the beginning of a file — handled by editorconfig
-dotnet_diagnostic.RCS0058.severity = none # Normalize whitespace at the end of a file — covered by SST1518
-dotnet_diagnostic.RCS0059.severity = none # Place new line after/before null-conditional operator — StyleSharp wrapping rules cover this
-dotnet_diagnostic.RCS0060.severity = none # Add/remove line after file scoped namespace declaration — formatting preference
-dotnet_diagnostic.RCS0061.severity = none # Add/remove blank line between switch sections — formatting preference
-dotnet_diagnostic.RCS0062.severity = none # Put expression body on its own line — formatting preference
-dotnet_diagnostic.RCS0063.severity = none # Remove unnecessary blank line — covered by SST1505 / SST1507
 
 ###################
 # StyleSharp Analyzers (SST)
@@ -1098,25 +834,23 @@ dotnet_diagnostic.RCS0063.severity = none # Remove unnecessary blank line — co
 file_header_template = Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.\nReactiveUI Association Incorporated licenses this file to you under the MIT license.\nSee the LICENSE file in the project root for full license information.
 stylesharp.summary_single_line_max_length = 120
 
-# SonarAnalyzer's S4022 only ever flagged storage narrower than int; uint, long and ulong
-# passed silently. Match that, so retiring S4022 for SST2313 does not fail a build on an
-# enum that was deliberately widened.
-stylesharp.SST2313.allowed_enum_storage = int, uint, long, ulong
+stylesharp.SST2313.allowed_enum_storage = int, uint, long, ulong # deliberately widened enums stay legal
 
-# Documentation coverage scope (SST1600/SST1601/SST1602/SST1654).
-# Require documentation on every element, including private members.
-stylesharp.document_exposed_elements = true
+stylesharp.document_exposed_elements = true # Documentation coverage — every element, private members included
 stylesharp.document_internal_elements = true
 stylesharp.document_private_elements = true
 stylesharp.document_private_fields = true
 stylesharp.document_interfaces = all
 stylesharp.SST1305.allowed_hungarian_prefixes = rx
+stylesharp.tuple_element_naming = pascal_case # SST1316
 stylesharp.instance_member_qualification = omit_this
+stylesharp.use_var = always # SST2271; matches the csharp_style_var_* preferences above
 stylesharp.max_cyclomatic_complexity = 10
 stylesharp.max_cognitive_complexity = 15
 stylesharp.max_property_cognitive_complexity = 3
-# SST1484 also reports a field that shadows one inherited from a base type.
-stylesharp.SST1484.check_base_types = true
+stylesharp.SST1484.check_base_types = true # also report a field shadowed from a base type
+
+stylesharp.SST2403.allowed_escape_methods = WhenActivated, ToProperty # both hand this straight back, so nothing observes a half-built instance
 stylesharp.max_line_length = 200                           # SST1521 (characters; keeps the limit this repo has always enforced)
 stylesharp.max_file_lines = 1000                           # SST1522 (code lines; blank lines and comments do not count)
 # stylesharp.max_member_lines = 60                         # SST1523 (code lines)
@@ -1135,7 +869,7 @@ dotnet_diagnostic.SST1006.severity = error # A preprocessor keyword is preceded 
 dotnet_diagnostic.SST1007.severity = error # An operator keyword is not followed by a space
 dotnet_diagnostic.SST1008.severity = error # An opening parenthesis is followed by a space
 dotnet_diagnostic.SST1009.severity = error # A closing parenthesis is preceded by a space
-dotnet_diagnostic.SST1010.severity = none # An opening square bracket has adjacent whitespace — conflicts with modern collection expressions
+dotnet_diagnostic.SST1010.severity = none # Opening square bracket has adjacent whitespace — collection expressions need it
 dotnet_diagnostic.SST1011.severity = error # A closing square bracket is preceded by a space
 dotnet_diagnostic.SST1012.severity = error # An opening brace is not followed by a space on a single line
 dotnet_diagnostic.SST1013.severity = error # A closing brace is not preceded by a space on a single line
@@ -1172,15 +906,15 @@ dotnet_diagnostic.SST1114.severity = error # A blank line separates the declarat
 dotnet_diagnostic.SST1115.severity = error # A blank line separates a parameter from the preceding comma
 dotnet_diagnostic.SST1116.severity = error # A qualified name can be shortened without changing the symbol it binds to
 dotnet_diagnostic.SST1117.severity = error # Instance member access follows the configured this. qualification style
-dotnet_diagnostic.SST1118.severity = none # A parameter should not span multiple lines
+dotnet_diagnostic.SST1118.severity = none # A parameter spanning multiple lines — collides with the 200-char line limit
 dotnet_diagnostic.SST1119.severity = error # A numeric literal groups its digit separators irregularly
 dotnet_diagnostic.SST1120.severity = error # A comment contains no text
-dotnet_diagnostic.SST1121.severity = error # A framework type name is used instead of its built-in alias (opt-in rule, enabled here)
+dotnet_diagnostic.SST1121.severity = error # A framework type name is used instead of its built-in alias
 dotnet_diagnostic.SST1122.severity = error # An empty string literal is used instead of string.Empty
 dotnet_diagnostic.SST1123.severity = error # A #region is placed inside a code element body
 dotnet_diagnostic.SST1124.severity = error # A #region directive is used
 dotnet_diagnostic.SST1125.severity = error # A Nullable<T> type is written in long form instead of the T? shorthand
-dotnet_diagnostic.SST1127.severity = error # A generic type constraint shares a line with the declaration or another constraint
+dotnet_diagnostic.SST1127.severity = error # A generic type constraint shares a line with another constraint
 dotnet_diagnostic.SST1128.severity = error # A constructor initializer shares a line with the constructor signature
 dotnet_diagnostic.SST1129.severity = error # A value type is created with a parameterless constructor call instead of default
 dotnet_diagnostic.SST1130.severity = error # An anonymous delegate is used where a lambda expression is clearer
@@ -1245,7 +979,7 @@ dotnet_diagnostic.SST1188.severity = error # Use the 'default' literal instead o
 dotnet_diagnostic.SST1189.severity = error # Variables should not be self-assigned
 dotnet_diagnostic.SST1190.severity = error # Doubled negation operators should be removed
 dotnet_diagnostic.SST1191.severity = error # Long numeric literals should use digit separators
-dotnet_diagnostic.SST1192.severity = none # Control characters in string literals should be escaped
+dotnet_diagnostic.SST1192.severity = error # Control characters in string literals should be escaped
 dotnet_diagnostic.SST1193.severity = error # Keep initial member values with construction
 dotnet_diagnostic.SST1194.severity = error # Keep initial collection values with construction
 dotnet_diagnostic.SST1195.severity = error # Write null fallback with ??
@@ -1275,31 +1009,32 @@ dotnet_diagnostic.SST1216.severity = error # Using static directives should be p
 dotnet_diagnostic.SST1217.severity = error # Using static directives should be ordered alphabetically
 dotnet_diagnostic.SST1218.severity = error # Other members separate a method's overloads
 dotnet_diagnostic.SST1219.severity = error # A switch default clause is not placed last
-dotnet_diagnostic.SST1220.severity = error # An all-named argument list is in a different order than the parameters. Code fix reorders it to declaration order. Info.
-dotnet_diagnostic.SST1221.severity = error # `where` constraint clauses are not ordered to match the type-parameter list. Code fix reorders them. Info.
+dotnet_diagnostic.SST1220.severity = error # An all-named argument list is not in declaration order
+dotnet_diagnostic.SST1221.severity = error # where constraint clauses do not match the type-parameter order
+dotnet_diagnostic.SST1222.severity = error # An enum with explicit values declares them out of ascending order
 
 # Naming
-dotnet_diagnostic.SST1300.severity = none # Types and members should be PascalCase — naming duplicates existing analyzers
+dotnet_diagnostic.SST1300.severity = error # Types and members should be PascalCase
 dotnet_diagnostic.SST1302.severity = error # Interface names should begin with I
 dotnet_diagnostic.SST1303.severity = error # Const names should be PascalCase
 dotnet_diagnostic.SST1304.severity = error # Non-private readonly fields should be PascalCase
 dotnet_diagnostic.SST1305.severity = error # Field names should not use Hungarian notation
-dotnet_diagnostic.SST1306.severity = none # Field names should begin with a lower-case letter — private fields use _camelCase here
+dotnet_diagnostic.SST1306.severity = none # Field names should begin lower-case — private fields use _camelCase here
 dotnet_diagnostic.SST1307.severity = error # Accessible fields should be PascalCase
-dotnet_diagnostic.SST1308.severity = none # Field names should not be prefixed with m_ or s_ — too broad for existing conventions
+dotnet_diagnostic.SST1308.severity = none # Field names should not use m_ or s_ prefixes — too broad for our conventions
 dotnet_diagnostic.SST1309.severity = error # Private fields should be _camelCase
 dotnet_diagnostic.SST1310.severity = none # Field names should not contain underscores — conflicts with _camelCase
-dotnet_diagnostic.SST1311.severity = none # Static readonly fields should be PascalCase — we use _camelCase for private static readonly too
+dotnet_diagnostic.SST1311.severity = none # Static readonly fields should be PascalCase — we use _camelCase there too
 dotnet_diagnostic.SST1312.severity = error # Local variables should be camelCase
 dotnet_diagnostic.SST1313.severity = error # Parameters should be camelCase
 dotnet_diagnostic.SST1314.severity = error # Type parameters should begin with T
 dotnet_diagnostic.SST1315.severity = error # Union member names should match the configured casing
-dotnet_diagnostic.SST1316.severity = none # Tuple element names should use the configured casing — tuple naming is not enforced here
-dotnet_diagnostic.SST1317.severity = none # Asynchronous method names should end with 'Async' — conflicts with this project's Rx-compatibility and naming mechanism
+dotnet_diagnostic.SST1316.severity = error # Tuple element names should use the configured casing
+dotnet_diagnostic.SST1317.severity = none # Async method names should end with 'Async' — conflicts with our Rx naming
 dotnet_diagnostic.SST1318.severity = error # Overriding parameter names should match the base declaration
 dotnet_diagnostic.SST1319.severity = error # An enumeration's type name is not PascalCase
 dotnet_diagnostic.SST1320.severity = error # A parameter name matches its method's name
-dotnet_diagnostic.SST1321.severity = none # Public APIs intentionally use Async to describe asynchronous observable behavior without returning an awaitable.
+dotnet_diagnostic.SST1321.severity = none # Async naming without an awaitable return — deliberate on our public APIs
 
 # Maintainability
 dotnet_diagnostic.SST1400.severity = error # An element does not declare an access modifier
@@ -1313,12 +1048,12 @@ dotnet_diagnostic.SST1407.severity = error # Mixed-precedence arithmetic is not 
 dotnet_diagnostic.SST1408.severity = error # Mixed conditional operators are not parenthesized
 dotnet_diagnostic.SST1410.severity = error # An anonymous method has an empty parameter list
 dotnet_diagnostic.SST1411.severity = error # An attribute uses an empty argument list
-dotnet_diagnostic.SST1412.severity = none # Store files as UTF-8 with a byte order mark — conflicts with SST1450 (UTF-8 without BOM)
-dotnet_diagnostic.SST1413.severity = none # A multi-line initializer omits the trailing comma — trailing commas are not required here
+dotnet_diagnostic.SST1412.severity = none # Store files as UTF-8 with a BOM — conflicts with SST1450 (no BOM)
+dotnet_diagnostic.SST1413.severity = error # A multi-line initializer omits the trailing comma
 dotnet_diagnostic.SST1414.severity = error # A tuple type in a member signature has an unnamed element
-dotnet_diagnostic.SST1415.severity = error # An argument-exception constructor uses a string literal where nameof would track renames
-dotnet_diagnostic.SST1416.severity = none # Do not declare public members in a non-public type
-dotnet_diagnostic.SST1417.severity = suggestion # Namespace should match the folder structure
+dotnet_diagnostic.SST1415.severity = error # An argument-exception constructor uses a literal instead of nameof
+dotnet_diagnostic.SST1416.severity = none # Public members in a non-public type — reflection binding needs them public
+dotnet_diagnostic.SST1417.severity = none # Namespace should match the folder — BCL-namespace types cannot comply
 dotnet_diagnostic.SST1418.severity = error # Declare precedence when mixing the null-coalescing operator
 dotnet_diagnostic.SST1419.severity = error # Remove redundant modifiers
 dotnet_diagnostic.SST1420.severity = error # Trivial properties should be auto-implemented
@@ -1360,9 +1095,9 @@ dotnet_diagnostic.SST1455.severity = error # Unsafe modifiers should be used onl
 dotnet_diagnostic.SST1456.severity = error # Readonly fields should not store mutable source-defined structs
 dotnet_diagnostic.SST1457.severity = error # Global suppressions should point at real declarations
 dotnet_diagnostic.SST1458.severity = error # Global suppression targets should use declaration ids directly
-dotnet_diagnostic.SST1459.severity = error # Grouping parentheses should be removed when the parent syntax already isolates the expression
+dotnet_diagnostic.SST1459.severity = error # Grouping parentheses the parent syntax already isolates
 dotnet_diagnostic.SST1460.severity = error # Non-mutating struct members should be readonly
-dotnet_diagnostic.SST1461.severity = error # Private parameters that are never read should be removed
+dotnet_diagnostic.SST1461.severity = error # A parameter is never read anywhere in the member body
 dotnet_diagnostic.SST1462.severity = error # Suppressions for diagnostics already disabled by config should be removed
 dotnet_diagnostic.SST1463.severity = error # Symbol-name strings should use nameof
 dotnet_diagnostic.SST1464.severity = error # An else clause follows a branch that always jumps and can be unwrapped
@@ -1374,7 +1109,7 @@ dotnet_diagnostic.SST1469.severity = error # A non-nullable value type is compar
 dotnet_diagnostic.SST1470.severity = error # A trailing catch clause that only rethrows should be removed
 dotnet_diagnostic.SST1471.severity = error # Magic numbers should be named constants
 dotnet_diagnostic.SST1472.severity = error # Signatures should not declare too many parameters
-dotnet_diagnostic.SST1473.severity = error # A floating-point value is compared for exact equality (zero comparison allowed by default)
+dotnet_diagnostic.SST1473.severity = error # A floating-point value is compared for exact equality
 dotnet_diagnostic.SST1474.severity = error # Both sides of an operator are the same expression
 dotnet_diagnostic.SST1475.severity = error # A condition repeats an earlier one in the chain, so its branch cannot run
 dotnet_diagnostic.SST1476.severity = error # Every branch of a conditional has the same body
@@ -1389,8 +1124,8 @@ dotnet_diagnostic.SST1484.severity = error # A declaration shadows an outer fiel
 dotnet_diagnostic.SST1485.severity = error # A member that must not throw throws
 dotnet_diagnostic.SST1486.severity = error # The same string literal is repeated instead of being named
 dotnet_diagnostic.SST1487.severity = error # A collection element is assigned twice with nothing reading it in between
-dotnet_diagnostic.SST1488.severity = error # An exception type does not declare the standard constructors (parameterless waivable)
-dotnet_diagnostic.SST1489.severity = error # An exception type carries serialization members the target framework has obsoleted
+dotnet_diagnostic.SST1488.severity = error # An exception type does not declare the standard constructors
+dotnet_diagnostic.SST1489.severity = error # An exception type carries obsoleted serialization members
 dotnet_diagnostic.SST1490.severity = error # A base list names an interface the rest of the list already implies
 dotnet_diagnostic.SST1491.severity = error # A modifier restates the declaration's default
 dotnet_diagnostic.SST1492.severity = error # A value is tested against what it is then assigned, so the guard decides nothing
@@ -1400,13 +1135,13 @@ dotnet_diagnostic.SST1495.severity = error # '==' compares references on a type 
 dotnet_diagnostic.SST1496.severity = error # An abstract type declares nothing abstract
 dotnet_diagnostic.SST1497.severity = error # A local is declared and never read
 dotnet_diagnostic.SST1498.severity = error # Only a nested type uses a private member
-dotnet_diagnostic.SST1499.severity = error # A static field visible outside its type can still be changed (internal fields included by default)
+dotnet_diagnostic.SST1499.severity = error # A static field visible outside its type can still be changed
 
 # Layout
 dotnet_diagnostic.SST1500.severity = error # A brace in a multi-line construct shares its line with other code
 dotnet_diagnostic.SST1501.severity = error # A statement block is collapsed onto a single line
 dotnet_diagnostic.SST1502.severity = error # An element body is collapsed onto a single line
-dotnet_diagnostic.SST1503.severity = none # A control-flow statement omits the braces around its child statement — duplicate with existing brace preferences
+dotnet_diagnostic.SST1503.severity = error # A control-flow statement omits the braces around its child statement
 dotnet_diagnostic.SST1504.severity = error # The accessors of a property/event mix single-line and multi-line forms
 dotnet_diagnostic.SST1505.severity = error # An opening brace is followed by a blank line
 dotnet_diagnostic.SST1506.severity = error # An element documentation header is followed by a blank line
@@ -1428,15 +1163,19 @@ dotnet_diagnostic.SST1521.severity = error # A line is longer than the configure
 dotnet_diagnostic.SST1522.severity = error # A file has more code lines than the configured maximum (default 500)
 dotnet_diagnostic.SST1523.severity = error # A member has more code lines than the configured maximum (default 60)
 dotnet_diagnostic.SST1524.severity = error # A switch section has more code lines than the configured maximum (default 20)
-dotnet_diagnostic.SST1525.severity = error # A multi-statement `switch` section has no braces; the braces-on policy extends to switch sections. Code fix wraps it.
-dotnet_diagnostic.SST1526.severity = error # A wrapped binary expression places the operator inconsistently. Configurable (`before`/`after`, default before). Opt-in.
-dotnet_diagnostic.SST1527.severity = error # The `=>` of an expression-bodied member wraps inconsistently. Configurable. Opt-in.
+dotnet_diagnostic.SST1525.severity = error # A multi-statement switch section has no braces
+dotnet_diagnostic.SST1526.severity = error # A wrapped binary expression places the operator inconsistently
+dotnet_diagnostic.SST1527.severity = error # The => of an expression-bodied member wraps inconsistently
 dotnet_diagnostic.SST1528.severity = error # The `=` of a wrapped initializer wraps inconsistently. Configurable. Opt-in.
-dotnet_diagnostic.SST1529.severity = error # A wrapped `?.`/`.` call chain places the break inconsistently. Configurable. Opt-in.
-dotnet_diagnostic.SST1530.severity = error # A newline sits between a type declaration and its base list. Code fix pulls the base list onto the declaration line. Opt-in.
-dotnet_diagnostic.SST1531.severity = error # A short object initializer is split across lines. Code fix collapses it when it fits. Opt-in.
+dotnet_diagnostic.SST1529.severity = error # A wrapped call chain places the break inconsistently
+dotnet_diagnostic.SST1530.severity = error # A newline sits between a type declaration and its base list
+dotnet_diagnostic.SST1531.severity = error # A short object initializer is split across lines
 dotnet_diagnostic.SST1532.severity = error # A file mixes line endings. Configurable (`lf`/`crlf`, default lf). Opt-in.
-dotnet_diagnostic.SST1533.severity = error # A source file contains no code. Opt-in.
+dotnet_diagnostic.SST1533.severity = none # A source file contains no code — a polyfill behind #if is empty by design
+dotnet_diagnostic.SST1534.severity = none # Switch braces that scope nothing — conflicts with SST1525's braces-on policy
+dotnet_diagnostic.SST1535.severity = error # A constructor initializer colon should not be followed by a blank line
+dotnet_diagnostic.SST1536.severity = error # A conditional operator token should not be followed by a blank line
+dotnet_diagnostic.SST1537.severity = error # An expression-body arrow should not be followed by a blank line
 
 # Documentation
 dotnet_diagnostic.SST1600.severity = error # Externally visible members should be documented
@@ -1447,7 +1186,7 @@ dotnet_diagnostic.SST1605.severity = error # Partial element documentation shoul
 dotnet_diagnostic.SST1606.severity = error # The summary should have text
 dotnet_diagnostic.SST1607.severity = error # Partial element summary should have text
 dotnet_diagnostic.SST1608.severity = error # Documentation should not use the default placeholder summary
-dotnet_diagnostic.SST1609.severity = none # Property documentation should have a value
+dotnet_diagnostic.SST1609.severity = none # Property docs should have a value — it only restates the summary
 dotnet_diagnostic.SST1610.severity = error # Property value documentation should have text
 dotnet_diagnostic.SST1611.severity = error # Parameters should be documented
 dotnet_diagnostic.SST1612.severity = error # Parameter documentation should match the parameters
@@ -1483,14 +1222,16 @@ dotnet_diagnostic.SST1653.severity = error # Keep short documentation summaries 
 dotnet_diagnostic.SST1654.severity = error # Extension blocks should be documented with a summary
 dotnet_diagnostic.SST1655.severity = error # Extension block parameters should be documented
 dotnet_diagnostic.SST1656.severity = error # Extension block type parameters should be documented
-dotnet_diagnostic.SST1657.severity = error # Extension block documentation should reference a real parameter or type parameter
+dotnet_diagnostic.SST1657.severity = error # Extension block docs name an unknown parameter or type parameter
 dotnet_diagnostic.SST1658.severity = error # Documentation text repeats a word
 dotnet_diagnostic.SST1659.severity = error # A comment has no text at all
 dotnet_diagnostic.SST1660.severity = error # The `<param>` tags are not in parameter order. Code fix reorders them. Info.
-dotnet_diagnostic.SST1661.severity = error # A snippet uses `<c>`/`<code>` mismatched to single- vs multi-line content. Code fix swaps the tag. Info.
-dotnet_diagnostic.SST1662.severity = none # A thrown exception type has no `<exception>` documentation. Code fix adds the skeleton. Opt-in.
-dotnet_diagnostic.SST1663.severity = none # A `//` comment before a public member reads like a summary; use `///`. Code fix converts it. Opt-in.
-dotnet_diagnostic.SST1664.severity = none # A summary separates paragraphs with blank lines instead of `<para>`. Code fix wraps them. Opt-in.
+dotnet_diagnostic.SST1661.severity = error # A snippet uses <c>/<code> mismatched to its content
+dotnet_diagnostic.SST1662.severity = error # A thrown exception type has no <exception> documentation
+dotnet_diagnostic.SST1663.severity = error # A // comment before a public member reads like a summary
+dotnet_diagnostic.SST1664.severity = error # A summary separates paragraphs with blank lines instead of <para>
+dotnet_diagnostic.SST1665.severity = error # An <exception> names a type but says nothing about what triggers it
+dotnet_diagnostic.SST1666.severity = error # Documentation elements are out of the conventional order
 
 # Concurrency and modernization
 dotnet_diagnostic.SST1900.severity = error # see docs/rules/SST1900.md
@@ -1499,11 +1240,11 @@ dotnet_diagnostic.SST1902.severity = error # Do not lock on 'this', a Type, or a
 dotnet_diagnostic.SST1903.severity = error # Do not lock on a newly-created object
 dotnet_diagnostic.SST1904.severity = error # A lock targets a non-readonly field
 dotnet_diagnostic.SST1905.severity = error # An async method or converted delegate returns void
-dotnet_diagnostic.SST2000.severity = suggestion # A null check plus throw should use ArgumentNullException.ThrowIfNull
+dotnet_diagnostic.SST2000.severity = error # A null check plus throw should use ArgumentNullException.ThrowIfNull
 dotnet_diagnostic.SST2001.severity = error # Use ArgumentException.ThrowIfNullOrEmpty
 dotnet_diagnostic.SST2002.severity = error # Use ArgumentException.ThrowIfNullOrWhiteSpace
-dotnet_diagnostic.SST2003.severity = suggestion # A disposed check should use ObjectDisposedException.ThrowIf
-dotnet_diagnostic.SST2004.severity = suggestion # A range check should use an ArgumentOutOfRangeException.ThrowIf... helper
+dotnet_diagnostic.SST2003.severity = error # A disposed check should use ObjectDisposedException.ThrowIf
+dotnet_diagnostic.SST2004.severity = error # A range check should use an ArgumentOutOfRangeException.ThrowIf... helper
 dotnet_diagnostic.SST2005.severity = error # Use the 'is' type pattern instead of comparing an 'as' cast to null
 dotnet_diagnostic.SST2006.severity = error # Use the 'is not' pattern instead of negating an 'is' check
 dotnet_diagnostic.SST2007.severity = error # Use declaration patterns instead of an is check followed by a cast local
@@ -1516,41 +1257,42 @@ dotnet_diagnostic.SST2013.severity = error # An if whose entire body is another 
 dotnet_diagnostic.SST2014.severity = error # A goto jumps to a label
 dotnet_diagnostic.SST2015.severity = error # A ++ or -- is buried inside a larger expression
 dotnet_diagnostic.SST2016.severity = error # A DateTime on a visible signature loses its offset at the boundary
-dotnet_diagnostic.SST2017.severity = error # A .Date or .TimeOfDay read proves the value is only a date, or only a time of day
+dotnet_diagnostic.SST2017.severity = error # A .Date or .TimeOfDay read proves the value is only one of the two
 dotnet_diagnostic.SST2018.severity = error # A redundant null check sits beside an is type pattern
+dotnet_diagnostic.SST2019.severity = error # Test for null rather than for the object type
 
 # Modern language and library usage
 dotnet_diagnostic.SST1700.severity = error # An extension block declares no members
 dotnet_diagnostic.SST1701.severity = error # Two extension blocks in a type share the same receiver type
 dotnet_diagnostic.SST1702.severity = error # Extension blocks in a type are separated by other members
-dotnet_diagnostic.SST1703.severity = error # A classic this-parameter extension method is used where an extension block could be
+dotnet_diagnostic.SST1703.severity = error # A classic this-parameter extension method could be an extension block
 dotnet_diagnostic.SST1704.severity = error # A class declaring extension blocks is not named with an Extensions suffix
 dotnet_diagnostic.SST1705.severity = error # A class mixes classic extension methods with extension blocks
 dotnet_diagnostic.SST1706.severity = error # An extension block targets a broad receiver type such as object or dynamic
 dotnet_diagnostic.SST1707.severity = error # Extension blocks should be ordered by receiver type
-dotnet_diagnostic.SST1708.severity = error # An extension method never uses its `this` receiver, so it need not be an extension.
-dotnet_diagnostic.SST1709.severity = none # A method in a `*Extensions` class whose first parameter lacks `this`. Code fix converts it to an extension block. Opt-in.
+dotnet_diagnostic.SST1708.severity = error # An extension method never uses its this receiver
+dotnet_diagnostic.SST1709.severity = error # A method in an *Extensions class whose first parameter lacks this
 dotnet_diagnostic.SST1800.severity = error # Record classes should be sealed
 dotnet_diagnostic.SST1801.severity = error # A positional record parameter does not match the configured casing
 dotnet_diagnostic.SST1802.severity = error # A record declares a settable rather than init-only instance property
 dotnet_diagnostic.SST1803.severity = error # A record struct is not declared readonly
-dotnet_diagnostic.SST1804.severity = error # A positional record has an empty `{ }` body where `;` would do. Code fix rewrites it. Info.
+dotnet_diagnostic.SST1804.severity = error # A positional record has an empty { } body where ; would do
 dotnet_diagnostic.SST2100.severity = error # An empty collection creation can use []
 dotnet_diagnostic.SST2101.severity = error # An explicit collection creation can use [...]
 dotnet_diagnostic.SST2102.severity = error # A span-targeted stackalloc initializer can use a collection expression
 dotnet_diagnostic.SST2103.severity = error # A collection-builder factory call can use a collection expression
 dotnet_diagnostic.SST2104.severity = error # A short builder-local sequence can return a collection expression
-dotnet_diagnostic.SST2105.severity = error # A literal array materialized with LINQ can use the target collection expression directly
+dotnet_diagnostic.SST2105.severity = error # A literal array materialized with LINQ can use a collection expression
 dotnet_diagnostic.SST2200.severity = error # A single-use backing field can use the C# 14 field keyword
 dotnet_diagnostic.SST2201.severity = error # A return-only switch statement can use a switch expression
 dotnet_diagnostic.SST2202.severity = error # An object creation repeats an explicit target type
 dotnet_diagnostic.SST2203.severity = error # An array or string index can use from-end indexing
 dotnet_diagnostic.SST2204.severity = error # A string slice can use range syntax
-dotnet_diagnostic.SST2205.severity = none # An enum switch statement omits named enum values — duplicate of IDE0010 (disabled: too noisy for default/fallthrough) and S131; statement switches deliberately no-op omitted values, and a default to satisfy it is rejected by SST1179/S3532. SST2206 keeps the valuable switch-expression exhaustiveness check.
+dotnet_diagnostic.SST2205.severity = none # Enum switch statement omits named values — deliberate; SST2206 covers these
 dotnet_diagnostic.SST2206.severity = error # An enum switch expression omits named enum values
 dotnet_diagnostic.SST2207.severity = error # A null guard and return can keep the throw in the returned expression
 dotnet_diagnostic.SST2208.severity = error # An out variable can be declared at the call site
-dotnet_diagnostic.SST2209.severity = none # A null-forgiving operator has no local effect
+dotnet_diagnostic.SST2209.severity = error # A null-forgiving operator has no local effect
 dotnet_diagnostic.SST2210.severity = error # A nullable directive repeats the current file-local state
 dotnet_diagnostic.SST2211.severity = error # A nullable restore directive has no file-local state to restore
 dotnet_diagnostic.SST2212.severity = error # Literal UTF-8 byte data can use a u8 string literal
@@ -1583,63 +1325,68 @@ dotnet_diagnostic.SST2238.severity = error # Nested property patterns can use ex
 dotnet_diagnostic.SST2239.severity = error # Forwarding lambdas can use method groups
 dotnet_diagnostic.SST2240.severity = error # Delegate null checks can use conditional invocation
 dotnet_diagnostic.SST2241.severity = error # Constructors that only store parameters can use primary-constructor storage
-dotnet_diagnostic.SST2242.severity = error # Enum switch statement mappings should name every enum value or include a catch-all
+dotnet_diagnostic.SST2242.severity = error # Enum switch mappings should name every value or include a catch-all
 dotnet_diagnostic.SST2243.severity = error # A verbatim string with escapes or line breaks can use a raw string literal
 dotnet_diagnostic.SST2244.severity = error # A numeric literal's suffix is lower case
 dotnet_diagnostic.SST2245.severity = error # A for loop with only a condition should be a while loop
-dotnet_diagnostic.SST2246.severity = error # A chain of conditional expressions testing one value against constants can be a switch expression
+dotnet_diagnostic.SST2246.severity = error # A chain of conditionals against constants can be a switch expression
 dotnet_diagnostic.SST2247.severity = error # Consecutive locals copying one value's members in order can be a deconstruction
 dotnet_diagnostic.SST2248.severity = error # Two constant comparisons of the same value can fold into one is-pattern
-dotnet_diagnostic.SST2249.severity = error # A literal-format string.Format or literal concatenation can be an interpolated string
-dotnet_diagnostic.SST2250.severity = error # A bare local assigned once by the next statement can be an initialized declaration
+dotnet_diagnostic.SST2249.severity = error # A literal string.Format or concatenation can be interpolated
+dotnet_diagnostic.SST2250.severity = error # A bare local assigned by the next statement can be an initialized declaration
 dotnet_diagnostic.SST2251.severity = error # A method call names type arguments that inference would supply
 dotnet_diagnostic.SST2252.severity = error # A switch statement is nested inside another switch statement
-dotnet_diagnostic.SST2254.severity = none # A target-typed `new()` is written where an explicit type reads more clearly; the code fix restores `new TypeName(...)`. Opt-in — the counterpart to SST2202's target-typed direction, so a team enables at most one.
+dotnet_diagnostic.SST2254.severity = none # Explicit type where new() is written — counterpart to SST2202, enable one
 dotnet_diagnostic.SST2255.severity = error # A hand-written null-or-empty string test. Code fix uses `string.IsNullOrEmpty`.
-dotnet_diagnostic.SST2256.severity = error # An extension method called in static form. Code fix rewrites to instance form. Info.
-dotnet_diagnostic.SST2257.severity = error # A lambda block body that is a single `return`. Code fix uses an expression body. Info.
-dotnet_diagnostic.SST2258.severity = error # A redundant explicit delegate wrapper (`new EventHandler(M)`). Code fix drops it. Info.
+dotnet_diagnostic.SST2256.severity = error # An extension method called in static form
+dotnet_diagnostic.SST2257.severity = error # A lambda block body that is a single return
+dotnet_diagnostic.SST2258.severity = error # A redundant explicit delegate wrapper
 dotnet_diagnostic.SST2259.severity = error # A stray `;` after a type declaration. Code fix removes it. Info.
 dotnet_diagnostic.SST2260.severity = error # An `as` cast to a type the operand already has. Code fix removes it. Info.
 dotnet_diagnostic.SST2261.severity = error # `(x && !y)
-dotnet_diagnostic.SST2262.severity = error # A raw string literal whose content needs no raw syntax. Code fix demotes it. Info.
-dotnet_diagnostic.SST2263.severity = error # An infinite loop whose body re-derives its stop condition. Code fix hoists the condition into the header. Info.
+dotnet_diagnostic.SST2262.severity = error # A raw string literal whose content needs no raw syntax
+dotnet_diagnostic.SST2263.severity = error # An infinite loop whose body re-derives its stop condition
 dotnet_diagnostic.SST2264.severity = error # A numeric literal cast to an enum. Code fix names the member.
-dotnet_diagnostic.SST2265.severity = none # Consecutive fluent calls on one receiver can fold into a chain. Opt-in.
-dotnet_diagnostic.SST2266.severity = none # A local read exactly once can be inlined into that use. Opt-in.
-dotnet_diagnostic.SST2267.severity = none # Infinite loops written in mixed `while(true)`/`for(;;)` styles. Configurable. Opt-in.
-dotnet_diagnostic.SST2268.severity = none # Inconsistent `()` on object creation with an initializer. Configurable. Opt-in.
-dotnet_diagnostic.SST2269.severity = none # Inconsistent parentheses around a conditional's condition. Configurable. Opt-in.
-dotnet_diagnostic.SST2270.severity = none # Inconsistent explicit-vs-implicit array-creation type. Configurable. Opt-in.
-dotnet_diagnostic.SST2271.severity = none # `var`-vs-explicit local type per the configured preference. Configurable. Opt-in.
-dotnet_diagnostic.SST2272.severity = none # `[Flags]` member values written as mixed decimals and shifts. Configurable. Opt-in.
-dotnet_diagnostic.SST2273.severity = none # A function or loop body wraps its work in a trailing `if` that could be an early-exit guard clause. Code fix inverts it. Configurable threshold. Opt-in.
-dotnet_diagnostic.SST2274.severity = error # A value assigned with `as` and then null-checked is an `is` declaration pattern in one step. Code fix rewrites it.
-dotnet_diagnostic.SST2275.severity = error # A method whose block body is a single statement can use an expression body `=> expr`. Code fix rewrites it.
-dotnet_diagnostic.SST2276.severity = none # A constructor whose block body is a single statement can use an expression body. Code fix rewrites it. Opt-in.
-dotnet_diagnostic.SST2277.severity = none # An operator whose block body is a single `return` can use an expression body. Code fix rewrites it. Opt-in.
-dotnet_diagnostic.SST2278.severity = none # A conversion operator whose block body is a single `return` can use an expression body. Code fix rewrites it. Opt-in.
-dotnet_diagnostic.SST2279.severity = error # A get-only property whose getter is a single `return` can use a whole-member expression body. Code fix rewrites it.
-dotnet_diagnostic.SST2280.severity = error # A get-only indexer whose getter is a single `return` can use a whole-member expression body. Code fix rewrites it.
-dotnet_diagnostic.SST2281.severity = error # A local function whose block body is a single statement can use an expression body. Code fix rewrites it.
-dotnet_diagnostic.SST2282.severity = error # A reference-type `ReferenceEquals` check against `null` reads as an `is null` / `is not null` pattern. Code fix rewrites it.
-dotnet_diagnostic.SST2283.severity = error # A null guard that throws right before assigning the guarded value can fold into the assignment as `?? throw`. Code fix rewrites it.
+dotnet_diagnostic.SST2265.severity = error # Consecutive fluent calls on one receiver can fold into a chain
+dotnet_diagnostic.SST2266.severity = error # A local read exactly once can be inlined into that use
+dotnet_diagnostic.SST2267.severity = error # Infinite loops written in mixed `while(true)`/`for(;;)` styles. Configurable.
+dotnet_diagnostic.SST2268.severity = error # Inconsistent `()` on object creation with an initializer. Configurable.
+dotnet_diagnostic.SST2269.severity = error # Inconsistent parentheses around a conditional's condition. Configurable.
+dotnet_diagnostic.SST2270.severity = error # Inconsistent explicit-vs-implicit array-creation type. Configurable.
+dotnet_diagnostic.SST2271.severity = error # `var`-vs-explicit local type per the configured preference. Configurable.
+dotnet_diagnostic.SST2272.severity = error # `[Flags]` member values written as mixed decimals and shifts. Configurable.
+dotnet_diagnostic.SST2273.severity = error # A trailing if that could be an early-exit guard clause
+dotnet_diagnostic.SST2274.severity = error # An 'as' assignment plus null check is one is-declaration pattern
+dotnet_diagnostic.SST2275.severity = error # A method whose block body is a single statement can use => expr
+dotnet_diagnostic.SST2276.severity = error # A constructor whose block body is a single statement can use =>
+dotnet_diagnostic.SST2277.severity = error # An operator whose block body is a single return can use =>
+dotnet_diagnostic.SST2278.severity = error # A conversion operator whose block body is a single return can use =>
+dotnet_diagnostic.SST2279.severity = error # A get-only property whose getter is a single return can use =>
+dotnet_diagnostic.SST2280.severity = error # A get-only indexer whose getter is a single return can use =>
+dotnet_diagnostic.SST2281.severity = error # A local function whose block body is a single statement can use =>
+dotnet_diagnostic.SST2282.severity = error # A ReferenceEquals check against null reads as an is null pattern
+dotnet_diagnostic.SST2283.severity = error # A null guard before an assignment can fold into it as ?? throw
+dotnet_diagnostic.SST2284.severity = error # A statement steps a value by one through a compound assignment
+dotnet_diagnostic.SST2285.severity = error # A null guard is conjoined with a member read on the same value
+dotnet_diagnostic.SST2286.severity = error # ToString is called on a receiver already typed as string
+dotnet_diagnostic.SST2287.severity = error # A while loop owns its counter, so a for header would gather it
+dotnet_diagnostic.SST2288.severity = error # A conditional expression has a boolean literal in exactly one branch
 # Design
 dotnet_diagnostic.SST2300.severity = error # A class implements IDisposable but builds only half of the disposal pattern
 dotnet_diagnostic.SST2301.severity = error # A class implementing IEquatable<T> for itself can still be derived from
 dotnet_diagnostic.SST2302.severity = error # A type overloads an operator without the rest of the set it belongs to
 dotnet_diagnostic.SST2303.severity = error # A [Flags] enum's members are not distinct bit values
-dotnet_diagnostic.SST2304.severity = error # An event's delegate does not have the standard (object sender, TEventArgs e) shape
+dotnet_diagnostic.SST2304.severity = error # An event delegate lacks the (object sender, TEventArgs e) shape
 dotnet_diagnostic.SST2305.severity = error # A mutable collection property declares a caller-visible setter
 dotnet_diagnostic.SST2306.severity = error # A collection-returning member hands back null
-dotnet_diagnostic.SST2307.severity = error # A generic method's type parameter appears in no parameter, so no caller can infer it
+dotnet_diagnostic.SST2307.severity = error # A generic method type parameter appears in no parameter and cannot be inferred
 dotnet_diagnostic.SST2308.severity = error # An [Obsolete] attribute carries no message
-dotnet_diagnostic.SST2309.severity = error # An externally visible member declares an optional parameter, so callers bake in the default
+dotnet_diagnostic.SST2309.severity = error # An externally visible member declares an optional parameter
 dotnet_diagnostic.SST2310.severity = error # Deprecated code is still here; remove it once its last caller is gone
 dotnet_diagnostic.SST2311.severity = error # A visible const is copied into every assembly that reads it
 dotnet_diagnostic.SST2312.severity = error # A type is declared outside any namespace
 dotnet_diagnostic.SST2313.severity = error # An enum is stored as a type the project does not allow
-dotnet_diagnostic.SST2314.severity = none # An [Obsolete] has a message but no DiagnosticId — unusable here: ObsoleteAttribute.DiagnosticId is .NET 5+, and this source is shared with net462
+dotnet_diagnostic.SST2314.severity = none # [Obsolete] with a message but no DiagnosticId — the property is .NET 5+ only
 dotnet_diagnostic.SST2315.severity = error # A type owns a disposable field but does not implement IDisposable
 dotnet_diagnostic.SST2316.severity = error # A type declares Dispose or DisposeAsync without implementing IDisposable
 dotnet_diagnostic.SST2317.severity = error # A disposable type owns a raw IntPtr without a SafeHandle or finalizer
@@ -1648,19 +1395,20 @@ dotnet_diagnostic.SST2319.severity = error # An overload's optional default can 
 dotnet_diagnostic.SST2320.severity = error # An interface inherits two interfaces that declare the same member
 dotnet_diagnostic.SST2321.severity = error # Environment.Exit or Environment.FailFast is called from library code
 dotnet_diagnostic.SST2322.severity = error # A non-private readonly field holds a mutable collection callers can still change
-dotnet_diagnostic.SST2323.severity = error # A stateless abstract class declaring only public abstract members should be an interface
+dotnet_diagnostic.SST2323.severity = error # A stateless abstract class with only public abstract members
 dotnet_diagnostic.SST2324.severity = error # A member is declared more accessible than its containing type
 dotnet_diagnostic.SST2325.severity = error # An async method checks an argument after its first await
-dotnet_diagnostic.SST2326.severity = none # An interface-typed value is narrowed to a concrete implementation — this is a high-performance core library, not strictly SOLID code, and narrowing to a known runtime type is a normal fast-path technique here: foreach over IEnumerable<T> boxes List<T>'s struct enumerator (40 bytes per call, measured) where the indexed loop behind the type test allocates nothing
-dotnet_diagnostic.SST2327.severity = error # A type tests its own runtime type against a class instead of dispatching through a virtual member
+dotnet_diagnostic.SST2326.severity = none # Interface value narrowed to a concrete type — a deliberate fast path here
+dotnet_diagnostic.SST2327.severity = error # A type tests its own runtime type instead of dispatching virtually
 dotnet_diagnostic.SST2328.severity = error # A raw native pointer handle is exposed instead of a SafeHandle
 dotnet_diagnostic.SST2329.severity = error # A `[Flags]` enum declares no zero-valued member. Code fix adds `None = 0`.
-dotnet_diagnostic.SST2330.severity = error # A `[Flags]` member is a numeric literal equal to a combination of others (`All = 7`). Code fix writes `A
-dotnet_diagnostic.SST2331.severity = none # An enum leaves member values implicit, so their numbers depend on declaration order. Opt-in.
-dotnet_diagnostic.SST2332.severity = error # An auto-property's `private set` is only written during construction; make it get-only.
-dotnet_diagnostic.SST2333.severity = none # A generic comparison/equality contract is implemented without its non-generic counterpart. Opt-in.
-dotnet_diagnostic.SST2334.severity = none # A publicly visible type has no `[DebuggerDisplay]`. Opt-in.
-dotnet_diagnostic.SST2335.severity = none # Parts of a partial type disagree on the `static` modifier. Opt-in.
+dotnet_diagnostic.SST2330.severity = error # A [Flags] member literal equal to a combination of other members
+dotnet_diagnostic.SST2331.severity = error # An enum leaves member values implicit, so numbering follows declaration order
+dotnet_diagnostic.SST2332.severity = error # An auto-property private set is only written during construction
+dotnet_diagnostic.SST2333.severity = error # A generic equality contract lacks its non-generic counterpart
+dotnet_diagnostic.SST2334.severity = error # A publicly visible type has no `[DebuggerDisplay]`
+dotnet_diagnostic.SST2335.severity = error # Parts of a partial type disagree on the `static` modifier
+dotnet_diagnostic.SST2336.severity = error # A concrete attribute type declares no [AttributeUsage]
 
 # Correctness
 dotnet_diagnostic.SST2400.severity = error # Two arguments name each other's parameters and have been transposed
@@ -1672,7 +1420,7 @@ dotnet_diagnostic.SST2405.severity = error # A [DebuggerDisplay] string names a 
 dotnet_diagnostic.SST2406.severity = error # A loop's stop condition reads only variables the loop never writes
 dotnet_diagnostic.SST2407.severity = error # A declared event is never raised
 dotnet_diagnostic.SST2408.severity = error # A StringBuilder is filled and never read
-dotnet_diagnostic.SST2409.severity = error # A throw constructs a general exception type (Exception/SystemException/ApplicationException)
+dotnet_diagnostic.SST2409.severity = error # A throw constructs a general exception type
 dotnet_diagnostic.SST2410.severity = error # A created disposable is never disposed and never leaves the method
 dotnet_diagnostic.SST2411.severity = error # A for loop declares and tests a counter it never steps
 dotnet_diagnostic.SST2412.severity = error # A for loop update moves the counter away from its stop condition
@@ -1698,40 +1446,46 @@ dotnet_diagnostic.SST2431.severity = error # A ToString override can return null
 dotnet_diagnostic.SST2432.severity = error # GetType is called on a value that is already a System.Type
 dotnet_diagnostic.SST2433.severity = error # A caller-info parameter is not last in the list
 dotnet_diagnostic.SST2434.severity = error # An array is assigned through a covariant element type
-dotnet_diagnostic.SST2435.severity = error # A non-object base's value-equality Equals is used as a reference-equality fast path
+dotnet_diagnostic.SST2435.severity = error # A non-object base's value Equals used as a reference fast path
 dotnet_diagnostic.SST2436.severity = error # An event is raised with a null sender or null args
 dotnet_diagnostic.SST2437.severity = error # A generic type inherits from itself recursively
 dotnet_diagnostic.SST2438.severity = error # A catch that discards its exception logs at Error or Critical without it
-dotnet_diagnostic.SST2439.severity = error # An exception is passed as a log template argument instead of the exception parameter
+dotnet_diagnostic.SST2439.severity = error # An exception is passed as a log template argument
 dotnet_diagnostic.SST2440.severity = error # Log template arguments are transposed
 dotnet_diagnostic.SST2441.severity = error # A log template has an empty or non-identifier placeholder
 dotnet_diagnostic.SST2442.severity = error # A log template repeats a named placeholder
 dotnet_diagnostic.SST2443.severity = error # An ILogger is injected or created with the wrong category type
 dotnet_diagnostic.SST2444.severity = error # A regular expression pattern is invalid
-dotnet_diagnostic.SST2445.severity = error # A culture-sensitive custom date or time format is used without an invariant culture
+dotnet_diagnostic.SST2445.severity = error # A culture-sensitive date or time format without an invariant culture
 dotnet_diagnostic.SST2446.severity = error # A Stream.ReadAsync result is discarded through ConfigureAwait or a local
-dotnet_diagnostic.SST2448.severity = error # A combined or opaque delegate is removed with - or -=, which strips only a contiguous run
+dotnet_diagnostic.SST2447.severity = error # An integer subtraction is compared against literal zero
+dotnet_diagnostic.SST2448.severity = error # A combined delegate removed with -= strips only a contiguous run
 dotnet_diagnostic.SST2449.severity = error # A lambda or anonymous-method handler is removed with -=, which never matches it
-dotnet_diagnostic.SST2450.severity = error # A Debug.Assert condition performs a side effect that a release build compiles out
+dotnet_diagnostic.SST2450.severity = error # A Debug.Assert condition performs a side effect
 dotnet_diagnostic.SST2451.severity = error # Every constructor is private and no member ever creates an instance
 dotnet_diagnostic.SST2452.severity = error # A [Pure] method returns void, Task, or ValueTask, so it has no observable result
+dotnet_diagnostic.SST2453.severity = error # A ?? whose right operand is a constant null substitutes null for null
+dotnet_diagnostic.SST2454.severity = error # The result of an 'as' conversion is dereferenced with no null check
+dotnet_diagnostic.SST2455.severity = error # Two enum members hold the same number without saying so
 dotnet_diagnostic.SST2456.severity = error # An override or new field-like event gets its own backing delegate field
 dotnet_diagnostic.SST2457.severity = error # An integer Sum wrapped in unchecked still throws on overflow
 dotnet_diagnostic.SST2458.severity = error # A bitwise operator is applied to an enum not declared [Flags]
 dotnet_diagnostic.SST2459.severity = error # [Optional] on a ref or out parameter advertises an optionality no caller can use
 dotnet_diagnostic.SST2460.severity = error # [DefaultValue] on a method or record parameter is inert
+dotnet_diagnostic.SST2461.severity = error # A [Flags] member sets a bit that no member of the enum declares
 dotnet_diagnostic.SST2462.severity = error # A new member is less accessible than the inherited member it hides
 dotnet_diagnostic.SST2463.severity = error # A field differs from an inherited accessible field only by case
-dotnet_diagnostic.SST2464.severity = error # A mutable class declares a value-equality operator ==, so it is lost as a hash key
+dotnet_diagnostic.SST2464.severity = error # A mutable class declares value-equality ==, so it is lost as a hash key
 dotnet_diagnostic.SST2465.severity = error # A for loop body reassigns the counter or the local its condition tests
-dotnet_diagnostic.SST2467.severity = error # A params overload is shadowed by a same-arity overload with a more specific last parameter
-dotnet_diagnostic.SST2468.severity = error # A classic partial method is declared but never implemented, so its calls are removed
-dotnet_diagnostic.SST2470.severity = error # Two string literals concatenate with no space, fusing a SQL keyword into the next token
+dotnet_diagnostic.SST2466.severity = error # A finally clause contains no statements
+dotnet_diagnostic.SST2467.severity = error # A params overload is shadowed by a same-arity overload
+dotnet_diagnostic.SST2468.severity = error # A classic partial method is declared but never implemented
+dotnet_diagnostic.SST2470.severity = error # Two string literals concatenate with no space, fusing keywords
 dotnet_diagnostic.SST2472.severity = error # A type is exported for a contract it neither implements nor inherits
 dotnet_diagnostic.SST2473.severity = error # A shared export part is constructed with new, bypassing the container
 dotnet_diagnostic.SST2474.severity = error # A part-creation-policy attribute is applied to a type with no [Export]
 dotnet_diagnostic.SST2475.severity = error # An entity's primary key is typed DateTime or DateTimeOffset
-dotnet_diagnostic.SST2479.severity = error # A loop variable captured by a callback stored beyond the iteration reads its final value
+dotnet_diagnostic.SST2479.severity = error # A loop variable captured beyond the iteration reads its final value
 dotnet_diagnostic.SST2481.severity = error # A GetHashCode override folds the base identity hash into a value hash
 dotnet_diagnostic.SST2484.severity = error # A handle read through DangerousGetHandle is not reference-counted
 dotnet_diagnostic.SST2485.severity = error # A NotImplementedException is left in shipped code
@@ -1740,17 +1494,19 @@ dotnet_diagnostic.SST2487.severity = error # A [ConstructorArgument] does not na
 dotnet_diagnostic.SST2488.severity = error # An exception is logged and rethrown, duplicating the record
 dotnet_diagnostic.SST2489.severity = error # A relational comparison is decided by the operand's type rather than its value
 dotnet_diagnostic.SST2490.severity = error # Adjacent try statements with identical handling should be merged
-dotnet_diagnostic.SST2491.severity = error # A non-`async` method returns an awaitable from inside `using`/`try-finally`/`lock`, so the resource is torn down before the task completes. Code fix makes it `async`.
+dotnet_diagnostic.SST2491.severity = error # A non-async method returns an awaitable from inside using or lock
 dotnet_diagnostic.SST2492.severity = error # A null-guard throws on a parameter the signature declares may be null.
-dotnet_diagnostic.SST2493.severity = error # `== null`/`!= null` on an unconstrained generic `T`. Code fix uses `is null`/`is not null`.
-dotnet_diagnostic.SST2494.severity = error # A `??` whose left operand is a constant null, so the right is always taken. Code fix folds it.
-dotnet_diagnostic.SST2495.severity = error # A `[Flags]` combination includes an operand whose bits another already covers. Code fix removes it.
-dotnet_diagnostic.SST2496.severity = error # An explicit `Dispose`/`Close` on a resource an enclosing `using` already disposes. Code fix removes it. Info.
+dotnet_diagnostic.SST2493.severity = error # == null or != null on an unconstrained generic T
+dotnet_diagnostic.SST2494.severity = error # A ?? whose left operand is a constant null
+dotnet_diagnostic.SST2495.severity = error # A [Flags] combination includes bits another operand already covers
+dotnet_diagnostic.SST2496.severity = error # An explicit Dispose/Close an enclosing using already performs
+dotnet_diagnostic.SST2497.severity = error # A member forwards to itself, so calling it recurses until the stack is gone
+dotnet_diagnostic.SST2498.severity = error # nameof on a type parameter is the constant "T"
 
 # Testing
 dotnet_diagnostic.SST2500.severity = error # A test method contains no assertion and no expected-exception check
 dotnet_diagnostic.SST2501.severity = error # An equality or identity assertion compares an expression with itself
-dotnet_diagnostic.SST2502.severity = error # An equality assertion passes the constant as actual and the computed value as expected
+dotnet_diagnostic.SST2502.severity = error # An equality assertion has expected and actual transposed
 dotnet_diagnostic.SST2503.severity = error # An equality assertion compares a value against a boolean literal
 dotnet_diagnostic.SST2504.severity = error # A test fixture declares and inherits no test method
 dotnet_diagnostic.SST2505.severity = error # A test method declares parameters but no data source
@@ -1760,24 +1516,24 @@ dotnet_diagnostic.SST2508.severity = error # A fluent assertion is started but n
 dotnet_diagnostic.SST2509.severity = error # A test method has a shape the runner cannot execute
 
 # Logging
-dotnet_diagnostic.SST2600.severity = error # Application output is written through legacy Trace instead of a structured logger
+dotnet_diagnostic.SST2600.severity = error # Output written through legacy Trace instead of a structured logger
 dotnet_diagnostic.SST2601.severity = error # A logger field or property does not follow the logger naming convention
 
 # Frameworks
-dotnet_diagnostic.SST2700.severity = error # An MVC route template contains a backslash; route segments are separated by `/`, so the route is unreachable. Code fix replaces `\` with `/`.
-dotnet_diagnostic.SST2701.severity = error # A `[JSInvokable]` method is not public, so JavaScript interop cannot call it. Code fix makes it public.
-dotnet_diagnostic.SST2702.severity = error # A `[SupplyParameterFromQuery]` property has a type the framework cannot bind from the query string, which throws at runtime.
-dotnet_diagnostic.SST2703.severity = error # A routable component's route constraint (`{id:int}`) disagrees with the matching `[Parameter]` CLR type, so the route silently fails to match.
-dotnet_diagnostic.SST2704.severity = error # A public action on an `[ApiController]` declares no HTTP-verb attribute, so it answers every verb and can make routing ambiguous.
-dotnet_diagnostic.SST2705.severity = none # A bound model member is a non-nullable value type with no required marker, so a request that omits it binds the default with no error. Opt-in.
-dotnet_diagnostic.SST2706.severity = error # A Windows Forms entry point carries neither `[STAThread]` nor `[MTAThread]`; without STA, clipboard, drag-and-drop, and common dialogs misbehave. Code fix adds `[STAThread]`.
-dotnet_diagnostic.SST2707.severity = none # A fire-and-forget `Task.Run` in a controller captures the request's `HttpContext`, which is disposed when the request ends, so the background work throws `ObjectDisposedException`. Opt-in.
-dotnet_diagnostic.SST2708.severity = error # A component subscribes to an event in a lifecycle method but never unsubscribes, so the event source keeps the component alive — a per-session leak on a Server circuit.
-dotnet_diagnostic.SST2709.severity = error # `StateHasChanged` is called while the component is being disposed, which the renderer no longer supports and throws.
-dotnet_diagnostic.SST2710.severity = error # `StateHasChanged` is called directly from a timer callback, off the renderer's dispatcher; marshal it with `InvokeAsync(StateHasChanged)`.
-dotnet_diagnostic.SST2711.severity = error # A synchronous component lifecycle method is overridden as `async void`, which the framework never awaits; override the `…Async` twin returning `Task`. Code fix rewrites the signature.
-dotnet_diagnostic.SST2712.severity = error # An `[Inject]`/`[CascadingParameter]` property has no setter, so the framework's reflection-based binding leaves it null. Code fix adds a setter.
-dotnet_diagnostic.SST2713.severity = error # A `DotNetObjectReference.Create(this)` is passed inline and never stored, so nothing can dispose it and it leaks on the JavaScript side.
+dotnet_diagnostic.SST2700.severity = error # An MVC route template contains a backslash, so the route is unreachable
+dotnet_diagnostic.SST2701.severity = error # A [JSInvokable] method is not public, so interop cannot call it
+dotnet_diagnostic.SST2702.severity = error # A [SupplyParameterFromQuery] property cannot bind from the query string
+dotnet_diagnostic.SST2703.severity = error # A route constraint disagrees with the matching [Parameter] CLR type
+dotnet_diagnostic.SST2704.severity = error # An [ApiController] action declares no HTTP-verb attribute
+dotnet_diagnostic.SST2705.severity = error # A bound model member is a non-nullable value type with no required marker
+dotnet_diagnostic.SST2706.severity = error # A Windows Forms entry point carries neither [STAThread] nor [MTAThread]
+dotnet_diagnostic.SST2707.severity = error # A fire-and-forget Task.Run in a controller captures the request HttpContext
+dotnet_diagnostic.SST2708.severity = error # A component subscribes to an event and never unsubscribes
+dotnet_diagnostic.SST2709.severity = error # StateHasChanged is called while the component is being disposed
+dotnet_diagnostic.SST2710.severity = error # StateHasChanged is called from a timer callback, off the dispatcher
+dotnet_diagnostic.SST2711.severity = error # A component lifecycle method is overridden as async void
+dotnet_diagnostic.SST2712.severity = error # An [Inject] or [CascadingParameter] property has no setter
+dotnet_diagnostic.SST2713.severity = error # A DotNetObjectReference.Create(this) is passed inline and never stored
 
 ###################
 # PerformanceSharp Analyzers (PSH)
@@ -1787,13 +1543,13 @@ performancesharp.avoid_linq_on_hot_path = true
 # performancesharp.excluded_properties = Items, Keys       # PSH1017 (comma-separated; properties allowed to copy on read)
 # performancesharp.include_public = false                  # PSH1411 (set true in an app to seal public types too; a break in a library)
 dotnet_diagnostic.PSH1000.severity = error # Anonymous functions without captures should be static
-dotnet_diagnostic.PSH1001.severity = error # Avoid allocating zero-length arrays (fix prefers [] on C# 12+, else Array.Empty<T>())
+dotnet_diagnostic.PSH1001.severity = error # Avoid allocating zero-length arrays
 dotnet_diagnostic.PSH1002.severity = error # Empty finalizers should be removed
 dotnet_diagnostic.PSH1003.severity = error # 'in' parameters should use readonly structs
 dotnet_diagnostic.PSH1004.severity = error # Constant arrays passed as arguments should be hoisted
 dotnet_diagnostic.PSH1005.severity = error # Structs should define equality members to avoid boxing comparisons
 dotnet_diagnostic.PSH1006.severity = error # ConcurrentDictionary factories should use the lambda argument
-dotnet_diagnostic.PSH1007.severity = error # Pass large readonly structs by 'in' reference (size threshold + exclusions configurable)
+dotnet_diagnostic.PSH1007.severity = error # Pass large readonly structs by 'in' reference
 dotnet_diagnostic.PSH1008.severity = error # GC.SuppressFinalize does nothing for sealed finalizer-free types
 dotnet_diagnostic.PSH1009.severity = error # Bound variable-length stackalloc with a constant guard
 dotnet_diagnostic.PSH1010.severity = error # Clear reference-typed arrays when returning them to the pool
@@ -1803,15 +1559,16 @@ dotnet_diagnostic.PSH1013.severity = error # Expose constant UTF-8 data as a Rea
 dotnet_diagnostic.PSH1014.severity = error # Declare immutable structs as readonly
 dotnet_diagnostic.PSH1015.severity = error # Avoid casting value types through object
 dotnet_diagnostic.PSH1016.severity = error # Test enum flags with bitwise operators instead of Enum.HasFlag
-dotnet_diagnostic.PSH1017.severity = error # A property allocates a copy of a collection on every read (excludable via performancesharp.PSH1017.excluded_properties)
+dotnet_diagnostic.PSH1017.severity = error # A property allocates a copy of a collection on every read
 dotnet_diagnostic.PSH1018.severity = error # A hand-written array is passed to a params parameter
 dotnet_diagnostic.PSH1019.severity = error # The range indexer on an array allocates a copy; slice with AsSpan/AsMemory
 dotnet_diagnostic.PSH1020.severity = error # Prefer a jagged array over a multidimensional one
-dotnet_diagnostic.PSH1021.severity = error # An explicit GC.Collect or GC.WaitForPendingFinalizers forces collection the runtime tunes itself
-dotnet_diagnostic.PSH1022.severity = error # A parameterless `new EventArgs()` allocates where the shared `EventArgs.Empty` singleton would serve. Code fix uses the singleton.
+dotnet_diagnostic.PSH1021.severity = error # An explicit GC.Collect forces collection the runtime tunes itself
+dotnet_diagnostic.PSH1022.severity = error # A parameterless new EventArgs() where EventArgs.Empty would serve
+dotnet_diagnostic.PSH1023.severity = error # A local anonymous type allocates where a tuple would not
 dotnet_diagnostic.PSH1100.severity = error # Hot-path code should avoid System.Linq.Enumerable calls
-dotnet_diagnostic.PSH1101.severity = none # LINQ terminal predicate simplification is reserved for test code; production code should avoid LINQ on hot paths
-dotnet_diagnostic.PSH1102.severity = none # LINQ type-filter simplification is reserved for test code; production code should avoid LINQ on hot paths
+dotnet_diagnostic.PSH1101.severity = none # LINQ predicate simplification — production code avoids LINQ on hot paths
+dotnet_diagnostic.PSH1102.severity = none # LINQ type-filter simplification — production code avoids LINQ on hot paths
 dotnet_diagnostic.PSH1103.severity = error # Prefer the collection's own count over enumerating
 dotnet_diagnostic.PSH1104.severity = error # Use TryGetValue instead of ContainsKey followed by an indexer read
 dotnet_diagnostic.PSH1105.severity = error # Avoid double lookups on dictionaries and sets
@@ -1821,9 +1578,9 @@ dotnet_diagnostic.PSH1108.severity = error # Chain secondary sorts with ThenBy
 dotnet_diagnostic.PSH1109.severity = error # Merge consecutive Where calls
 dotnet_diagnostic.PSH1110.severity = error # Use the collection's own predicate methods over LINQ
 dotnet_diagnostic.PSH1111.severity = error # Use Contains for membership tests
-dotnet_diagnostic.PSH1112.severity = error # Seed the collection through its constructor (fix honors performancesharp.prefer_collection_expressions)
+dotnet_diagnostic.PSH1112.severity = error # Seed the collection through its constructor
 dotnet_diagnostic.PSH1113.severity = error # Sort naturally instead of ordering by the element itself
-dotnet_diagnostic.PSH1114.severity = none # Freeze static lookup collections that are never mutated. Opt-in.
+dotnet_diagnostic.PSH1114.severity = error # Freeze static lookup collections that are never mutated
 dotnet_diagnostic.PSH1115.severity = error # Insert-if-absent should probe the dictionary once
 dotnet_diagnostic.PSH1116.severity = error # Probe string-keyed collections with a span through GetAlternateLookup
 dotnet_diagnostic.PSH1117.severity = error # Ask the collection whether it is empty
@@ -1861,18 +1618,18 @@ dotnet_diagnostic.PSH1222.severity = error # Concatenate slices without material
 dotnet_diagnostic.PSH1223.severity = error # A reused composite format string is re-parsed on every call
 dotnet_diagnostic.PSH1224.severity = error # Convert bytes to hex in one call, not by building the string twice
 dotnet_diagnostic.PSH1225.severity = error # Decode bytes to a string in one call, without a throwaway char[]
-dotnet_diagnostic.PSH1226.severity = error # A string's `ToCharArray()` result is only iterated, allocating a throwaway `char[]`; iterate the string directly. Code fix drops the copy.
-dotnet_diagnostic.PSH1227.severity = error # A cheaper equivalent exists — `string.CompareOrdinal` over `Compare(…, Ordinal)`, `Debug.Fail` over `Debug.Assert(false, …)`. Info. Code fix rewrites the call.
+dotnet_diagnostic.PSH1226.severity = error # A string's ToCharArray() result is only iterated
+dotnet_diagnostic.PSH1227.severity = error # A cheaper equivalent exists, such as string.CompareOrdinal or Debug.Fail
 dotnet_diagnostic.PSH1300.severity = error # Use System.Threading.Lock for a dedicated lock object
 dotnet_diagnostic.PSH1301.severity = error # Do not wrap a single task in WhenAll or WaitAll
 dotnet_diagnostic.PSH1302.severity = error # TaskCompletionSource should run continuations asynchronously
 dotnet_diagnostic.PSH1303.severity = error # Do not block an async method with Thread.Sleep
 dotnet_diagnostic.PSH1304.severity = error # Use PeriodicTimer instead of pacing a loop with Task.Delay
 dotnet_diagnostic.PSH1305.severity = error # Enumerate a ConcurrentDictionary directly, not its Keys/Values snapshots
-dotnet_diagnostic.PSH1306.severity = none # Guard one-time execution with an interlocked latch. Opt-in.
+dotnet_diagnostic.PSH1306.severity = error # Guard one-time execution with an interlocked latch
 dotnet_diagnostic.PSH1307.severity = error # Access interlocked fields with Volatile
 dotnet_diagnostic.PSH1308.severity = error # Return the completed task instead of Task.FromResult
-dotnet_diagnostic.PSH1309.severity = none # Register cancellation callbacks without flowing the execution context. Opt-in.
+dotnet_diagnostic.PSH1309.severity = error # Register cancellation callbacks without flowing the execution context
 dotnet_diagnostic.PSH1310.severity = error # Dispose IAsyncDisposable resources with await using in async code
 dotnet_diagnostic.PSH1311.severity = error # Remove a pass-through async state machine and return the task directly
 dotnet_diagnostic.PSH1312.severity = error # Return a completed task instead of null
@@ -1890,7 +1647,7 @@ dotnet_diagnostic.PSH1406.severity = error # Ask Regex for the answer directly
 dotnet_diagnostic.PSH1407.severity = error # Query the dictionary, not its Keys view
 dotnet_diagnostic.PSH1408.severity = error # Measure elapsed time with Stopwatch timestamps
 dotnet_diagnostic.PSH1409.severity = error # Use the built-in throw helpers for argument guards
-dotnet_diagnostic.PSH1410.severity = none # Mark trivial forwarders for aggressive inlining. Opt-in.
+dotnet_diagnostic.PSH1410.severity = error # Mark trivial forwarders for aggressive inlining
 dotnet_diagnostic.PSH1411.severity = error # Seal non-public types nothing derives from so the JIT can devirtualize
 dotnet_diagnostic.PSH1412.severity = error # Use Random.Shared instead of allocating a Random
 dotnet_diagnostic.PSH1413.severity = error # Read the Unix epoch from the framework, not a hand-built DateTime
@@ -1899,22 +1656,23 @@ dotnet_diagnostic.PSH1415.severity = error # Hold the concrete type when the con
 dotnet_diagnostic.PSH1416.severity = error # Cache the serializer options instead of building them per call
 dotnet_diagnostic.PSH1417.severity = error # Do not compute an expensive argument for an assertion
 dotnet_diagnostic.PSH1418.severity = error # An HttpClient is constructed on every call
-dotnet_diagnostic.PSH1419.severity = error # A time-zone is resolved with a platform-specific id instead of the cross-platform API
-dotnet_diagnostic.PSH1420.severity = error # A shareable client held in an instance field of an Azure Functions worker class is rebuilt on every invocation, leaking sockets and connections; share a static/singleton client or inject `IHttpClientFactory`.
+dotnet_diagnostic.PSH1419.severity = error # A time zone is resolved with a platform-specific id
+dotnet_diagnostic.PSH1420.severity = error # A shareable client is rebuilt on every Azure Functions invocation
+dotnet_diagnostic.PSH1421.severity = error # A static Regex method is called from inside a loop body
 
 # ASP.NET Core - inert in this repo (no route handlers or middleware), enabled so the set stays complete
 dotnet_diagnostic.PSH1500.severity = error # A minimal API handler returns Results instead of TypedResults, boxing the result
-dotnet_diagnostic.PSH1501.severity = error # Middleware uses the legacy nested-delegate Use overload, allocating a per-request closure
-dotnet_diagnostic.PSH1502.severity = error # A route handler returns a deferred sequence the serializer enumerates on the request thread
+dotnet_diagnostic.PSH1501.severity = error # Middleware uses the legacy nested-delegate Use overload
+dotnet_diagnostic.PSH1502.severity = error # A route handler returns a sequence serialized on the request thread
 dotnet_diagnostic.PSH1503.severity = error # Response caching is used where server-side output caching applies
-dotnet_diagnostic.PSH1505.severity = error # Exceptions are handled in an MVC exception filter instead of an IExceptionHandler
-dotnet_diagnostic.PSH1506.severity = error # The HTTP request or response body is read or written synchronously (`ReadToEnd`, `Body.Read`, `Body.Write`), which blocks a thread on Kestrel and buffers the whole payload; use the async overload. Code fix awaits it when the method is already async.
+dotnet_diagnostic.PSH1505.severity = error # Exceptions handled in an MVC filter instead of an IExceptionHandler
+dotnet_diagnostic.PSH1506.severity = error # The HTTP request or response body is read or written synchronously
 
 # Blazor
-dotnet_diagnostic.PSH1600.severity = error # A delegate captured per iteration inside a component render loop reallocates on every render (measured ~128 B per row per render) and churns the diff; hoist it to a cached delegate or a precomputed per-item model.
-dotnet_diagnostic.PSH1601.severity = error # A JavaScript-interop call is issued once per loop iteration; on Interactive Server each is a separate SignalR round-trip. Batch into a single call over the collection.
-dotnet_diagnostic.PSH1602.severity = error # `StateHasChanged` is called unconditionally in `OnAfterRender`/`OnAfterRenderAsync`, scheduling another render every time — a runaway loop. Guard it with `firstRender` or a state flag.
-dotnet_diagnostic.PSH1603.severity = error # A non-delegate allocation is used as a component-parameter value inside a render loop, allocating per item and forcing the child to re-render each pass. Sibling of PSH1600.
+dotnet_diagnostic.PSH1600.severity = error # A delegate captured per iteration in a render loop reallocates every render
+dotnet_diagnostic.PSH1601.severity = error # A JavaScript-interop call is issued once per loop iteration
+dotnet_diagnostic.PSH1602.severity = error # StateHasChanged is called unconditionally in OnAfterRender
+dotnet_diagnostic.PSH1603.severity = error # A non-delegate allocation is a component parameter in a render loop
 
 ###################
 # SecuritySharp Analyzers (SES)
@@ -1931,18 +1689,18 @@ dotnet_diagnostic.SES1002.severity = error # Password-based key derivation must 
 dotnet_diagnostic.SES1003.severity = error # Password-based key derivation must use a sufficient iteration count
 dotnet_diagnostic.SES1004.severity = error # A secret must not be produced from Guid.NewGuid()
 dotnet_diagnostic.SES1005.severity = error # Compare secret values in constant time
-dotnet_diagnostic.SES1006.severity = error # A Data Protection key ring is persisted without a ProtectKeysWith call, so keys sit unencrypted at rest
-dotnet_diagnostic.SES1007.severity = error # A cryptographic primitive is implemented by hand instead of using a vetted platform algorithm
-dotnet_diagnostic.SES1008.severity = error # An XML signature is verified with the no-key CheckSignature overload, trusting the document's own KeyInfo
+dotnet_diagnostic.SES1006.severity = error # A Data Protection key ring is persisted without ProtectKeysWith
+dotnet_diagnostic.SES1007.severity = error # A cryptographic primitive is implemented by hand
+dotnet_diagnostic.SES1008.severity = error # An XML signature is verified with the no-key CheckSignature overload
 dotnet_diagnostic.SES1009.severity = error # A password is stored without a slow, salted key-derivation function
 
 # Transport
 dotnet_diagnostic.SES1102.severity = error # Do not accept any server certificate
 dotnet_diagnostic.SES1104.severity = error # Certificate-chain validation must not be deliberately weakened
-dotnet_diagnostic.SES1105.severity = error # Bearer and OpenID Connect metadata must not be retrieved over plain HTTP outside development
+dotnet_diagnostic.SES1105.severity = error # Bearer or OpenID Connect metadata is retrieved over plain HTTP
 dotnet_diagnostic.SES1106.severity = error # Do not send HttpClient requests to a cleartext http URL
-dotnet_diagnostic.SES1107.severity = error # A SQL connection string weakens transport security via TrustServerCertificate or a disabled Encrypt
-dotnet_diagnostic.SES1108.severity = error # A custom server-certificate validation callback unconditionally returns true, so any certificate is trusted
+dotnet_diagnostic.SES1107.severity = error # A SQL connection string weakens transport security
+dotnet_diagnostic.SES1108.severity = error # A certificate validation callback unconditionally returns true
 
 # Secrets
 dotnet_diagnostic.SES1201.severity = error # Do not hard-code secrets in source
@@ -1966,8 +1724,8 @@ dotnet_diagnostic.SES1401.severity = error # A type resolved from non-constant d
 dotnet_diagnostic.SES1402.severity = error # Do not load an assembly from raw bytes or a non-constant location
 dotnet_diagnostic.SES1403.severity = error # JSON deserialization depth limit must stay within a safe ceiling
 dotnet_diagnostic.SES1404.severity = error # A type is instantiated by name from a non-constant Activator typeName
-dotnet_diagnostic.SES1405.severity = error # MessagePack typeless deserialization reconstructs whatever type the payload names
-dotnet_diagnostic.SES1406.severity = warning # Reflection must not reach non-public members via BindingFlags.NonPublic (opt-in; replaces S3011)
+dotnet_diagnostic.SES1405.severity = error # MessagePack typeless deserialization reconstructs the named type
+dotnet_diagnostic.SES1406.severity = error # Reflection must not reach non-public members via BindingFlags.NonPublic
 
 # Web hardening
 dotnet_diagnostic.SES1501.severity = error # A CORS policy must not allow credentials together with any origin
@@ -1978,10 +1736,10 @@ dotnet_diagnostic.SES1505.severity = error # The request body size limit must no
 dotnet_diagnostic.SES1506.severity = error # The developer exception page must be guarded by a development-environment check
 dotnet_diagnostic.SES1507.severity = error # AllowAnonymous and Authorize on the same declaration conflict
 dotnet_diagnostic.SES1508.severity = error # A validation method must not fail open by returning success from a catch
-dotnet_diagnostic.SES1509.severity = error # A backtracking-prone constant regex runs without a match timeout or NonBacktracking
+dotnet_diagnostic.SES1509.severity = error # A backtracking-prone regex runs without a match timeout
 dotnet_diagnostic.SES1510.severity = error # A controller redirects to a non-constant URL, allowing an open redirect
-dotnet_diagnostic.SES1511.severity = error # The forwarded-headers trust boundary is cleared, letting proxies spoof the client IP
-dotnet_diagnostic.SES1512.severity = error # Sensitive framework diagnostics are enabled without a development-environment guard
+dotnet_diagnostic.SES1511.severity = error # The forwarded-headers trust boundary is cleared
+dotnet_diagnostic.SES1512.severity = error # Sensitive diagnostics are enabled without an environment guard
 dotnet_diagnostic.SES1513.severity = error # An AuthorizeAsync result is discarded, so the guarded operation runs regardless
 dotnet_diagnostic.SES1514.severity = error # OpenID Connect protections (PKCE, state, nonce) are disabled
 dotnet_diagnostic.SES1515.severity = error # A Content-Security-Policy value disables its own protection
@@ -1989,30 +1747,29 @@ dotnet_diagnostic.SES1515.severity = error # A Content-Security-Policy value dis
 # AI trust boundaries
 dotnet_diagnostic.SES1601.severity = error # An LLM system prompt must be a constant, trusted template
 dotnet_diagnostic.SES1602.severity = error # Do not route AI model output into a process, file, or raw SQL sink
-dotnet_diagnostic.SES1603.severity = error # An AI tool declared read-only or non-destructive must not call a state-changing API
+dotnet_diagnostic.SES1603.severity = error # A read-only AI tool calls a state-changing API
 dotnet_diagnostic.SES1604.severity = error # Prompt-template input encoding must not be disabled
 dotnet_diagnostic.SES1605.severity = error # AI instrumentation must not enable sensitive-data capture
 dotnet_diagnostic.SES1606.severity = error # Do not fetch model weights over cleartext HTTP
 
 # Web UI trust boundaries
-dotnet_diagnostic.SES1701.severity = error # Raw HTML is rendered from a non-constant value (`MarkupString`/`AddMarkupContent`), bypassing automatic encoding — an XSS risk. Sanitizer allow-list via `securitysharp.SES1701.sanitizers`.
-dotnet_diagnostic.SES1702.severity = error # A JavaScript-interop call targets a script-evaluation primitive (`eval`, `Function`, `document.write`), turning interop into a script-injection channel.
-dotnet_diagnostic.SES1703.severity = error # `[Authorize]` on a non-routable component enforces nothing — authorization runs as a routing concern. Exempt types via `securitysharp.SES1703.exempt_types`.
-dotnet_diagnostic.SES1704.severity = error # `IHttpContextAccessor` or a cascading `HttpContext` is used in an interactively-rendered component, where it is null or frozen at circuit start.
-dotnet_diagnostic.SES1705.severity = error # `NavigationManager.NavigateTo` is called with a target that is not a verified relative URL — an open-redirect risk. Validator allow-list via `securitysharp.SES1705.validators`.
-dotnet_diagnostic.SES1706.severity = error # An uploaded file is read with an unbounded or client-chosen size limit, letting an attacker fill server memory. Threshold via `securitysharp.SES1706.max_bytes`.
-dotnet_diagnostic.SES1707.severity = error # A secret-shaped literal appears in code reachable as WebAssembly, which downloads to the browser in full — guaranteed disclosure.
-dotnet_diagnostic.SES1708.severity = error # `CircuitOptions.DetailedErrors` is enabled, shipping server exception detail to every connected client.
-dotnet_diagnostic.SES1709.severity = error # `SerializeAllClaims` serializes every claim into client-readable WebAssembly authentication state, exposing internal ids, tokens, and PII.
-dotnet_diagnostic.SES1710.severity = error # Antiforgery validation is disabled on a form (`[RequireAntiforgeryToken(required: false)]`), removing CSRF protection.
+dotnet_diagnostic.SES1701.severity = error # Raw HTML is rendered from a non-constant value — an XSS risk
+dotnet_diagnostic.SES1702.severity = error # A JavaScript-interop call targets a script-evaluation primitive
+dotnet_diagnostic.SES1703.severity = error # [Authorize] on a non-routable component enforces nothing
+dotnet_diagnostic.SES1704.severity = error # HttpContext is used in an interactively-rendered component
+dotnet_diagnostic.SES1705.severity = error # NavigateTo is called with an unverified target — open-redirect risk
+dotnet_diagnostic.SES1706.severity = error # An uploaded file is read with an unbounded or client-chosen size limit
+dotnet_diagnostic.SES1707.severity = error # A secret-shaped literal sits in code that downloads to the browser
+dotnet_diagnostic.SES1708.severity = error # CircuitOptions.DetailedErrors ships exception detail to clients
+dotnet_diagnostic.SES1709.severity = error # SerializeAllClaims exposes every claim to the client
+dotnet_diagnostic.SES1710.severity = error # Antiforgery validation is disabled on a form
 
 
 ###################
-# Microsoft.CodeAnalysis.PublicApiAnalyzers (RS)
+# Public API surface tracking (PAS)
 ###################
-# Public API surface tracking
-dotnet_diagnostic.RS0016.severity = error # public symbol missing from the PublicAPI baseline
-dotnet_diagnostic.RS0017.severity = error # PublicAPI baseline entry no longer in source
+# PAS0001/PAS0002/PAS0003/PAS0005 are errors by default and need no entry here.
+dotnet_diagnostic.PAS0004.severity = warning # no public API baseline for this target framework
 
 ###################
 # Microsoft.NET.ILLink.Analyzers (IL)
@@ -2146,551 +1903,55 @@ dotnet_diagnostic.IL3056.severity = error # MakeGenericMethod on non-supported m
 dotnet_diagnostic.IL3057.severity = error # Reflection access to generic parameter requires dynamic code
 
 ###################
-# SonarAnalyzer.CSharp (S)
+# External scanner inspections
 ###################
-# Repository suppressions
-dotnet_diagnostic.S1075.severity = none # Hardcoded URI — canonical SourceLink hosts are the point
-dotnet_diagnostic.S2436.severity = none # Too many generic parameters — needed for the projector overload
-dotnet_diagnostic.S4036.severity = none # PATH-relative process spawn — benchmark only, trusted env
-dotnet_diagnostic.S8969.severity = none # Nullability inference is inconsistent across the repository's target frameworks
-
-# Blocker bugs
-dotnet_diagnostic.S1048.severity = none # Finalizers should not throw exceptions — covered by SST1485
-dotnet_diagnostic.S2190.severity = none # Loops and recursions should not be infinite
-dotnet_diagnostic.S2275.severity = none # Composite format strings should not lead to unexpected behavior at runtime - DUPLICATE CA2241
-dotnet_diagnostic.S2857.severity = none # SQL keywords should be delimited by whitespace — covered by SST2470
-dotnet_diagnostic.S2930.severity = none # "IDisposables" should be disposed — covered by SST2410
-dotnet_diagnostic.S2931.severity = none # Classes with "IDisposable" members should implement "IDisposable" — covered by SST2315
-dotnet_diagnostic.S3464.severity = none # Type inheritance should not be recursive — covered by SST2437
-dotnet_diagnostic.S3869.severity = none # "SafeHandle.DangerousGetHandle" should not be called -> replaced by SST2484
-dotnet_diagnostic.S3889.severity = none # "Thread.Resume" and "Thread.Suspend" should not be used -> replaced by obsolete or compiler
-dotnet_diagnostic.S4159.severity = none # Classes should implement their "ExportAttribute" interfaces — covered by SST2472
-
-# Critical bugs
-dotnet_diagnostic.S2551.severity = none # Shared resources should not be used for locking — covered by SST1902
-dotnet_diagnostic.S2952.severity = none # Classes should "Dispose" of members from the classes' own "Dispose" methods -> replaced by SST2315
-dotnet_diagnostic.S3449.severity = none # Right operands of shift operators should be integers -> replaced by SST1478
-dotnet_diagnostic.S4275.severity = none # Getters and setters should access the expected fields — covered by SST2422
-dotnet_diagnostic.S4277.severity = none # "Shared" parts should not be created with "new" — covered by SST2473
-dotnet_diagnostic.S4583.severity = none # Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke" -> replaced by obsolete (APM BeginInvoke/EndInvoke)
-dotnet_diagnostic.S4586.severity = none # Non-async "Task/Task<T>" methods should not return null — covered by PSH1312
-dotnet_diagnostic.S5856.severity = none # Regular expressions should be syntactically valid — covered by SST2444
-dotnet_diagnostic.S6674.severity = none # Log message template should be syntactically correct — covered by SST2441
-
-# Major bugs
-dotnet_diagnostic.S1244.severity = none # Floating point numbers should not be tested for equality — covered by SST1473
-dotnet_diagnostic.S1656.severity = none # Variables should not be self-assigned — covered by SST1189
-dotnet_diagnostic.S1751.severity = none # Loops with at most one iteration should be refactored - covered by SST1444
-dotnet_diagnostic.S1764.severity = none # Identical expressions should not be used on both sides of operators — covered by SST1474
-dotnet_diagnostic.S1848.severity = none # Objects should not be created to be dropped immediately without being used -> replaced by SST1480
-dotnet_diagnostic.S1862.severity = none # Related "if/else if" statements should not have the same condition — covered by SST1475
-dotnet_diagnostic.S2114.severity = none # Collections should not be passed as arguments to their own methods — covered by SST2419
-dotnet_diagnostic.S2123.severity = none # Values should not be uselessly incremented -> replaced by SST2222
-dotnet_diagnostic.S2201.severity = none # Methods without side effects should not have their return values ignored — covered by SST2418
-dotnet_diagnostic.S2225.severity = none # "ToString()" method should not return null — covered by SST2431
-dotnet_diagnostic.S2251.severity = none # A "for" loop update clause should move the counter in the right direction — covered by SST2412
-dotnet_diagnostic.S2252.severity = none # For-loop conditions should be true at least once — covered by SST2413
-dotnet_diagnostic.S2445.severity = none # Blocks should be synchronized on read-only fields — covered by SST1904
-dotnet_diagnostic.S2688.severity = none # "NaN" should not be used in comparisons — covered by SST1473
-dotnet_diagnostic.S2757.severity = none # Non-existent operators like "=+" should not be used — covered by SST2417
-dotnet_diagnostic.S2761.severity = none # Doubled prefix operators "!!" and "~~" should not be used — covered by SST1190
-dotnet_diagnostic.S2995.severity = none # "Object.ReferenceEquals" should not be used for value types -> replaced by CA2013
-dotnet_diagnostic.S2996.severity = none # "ThreadStatic" fields should not be initialized -> replaced by CA2019
-dotnet_diagnostic.S2997.severity = none # "IDisposables" created in a "using" statement should not be returned — covered by SST2423
-dotnet_diagnostic.S3005.severity = none # "ThreadStatic" should not be used on non-static fields -> replaced by CA2259
-dotnet_diagnostic.S3168.severity = none # "async" methods should not return "void" — covered by SST1905
-dotnet_diagnostic.S3172.severity = none # Delegates should not be subtracted — covered by SST2448
-dotnet_diagnostic.S3244.severity = none # Anonymous delegates should not be used to unsubscribe from Events — covered by SST2449
-dotnet_diagnostic.S3249.severity = none # Covered by SST1447 (canonical)
-dotnet_diagnostic.S3263.severity = none # Static fields should appear in the order they must be initialized — covered by SST2428
-dotnet_diagnostic.S3343.severity = none # Caller information parameters should come at the end of the parameter list — covered by SST2433
-dotnet_diagnostic.S3346.severity = none # Expressions used in "Debug.Assert" should not produce side effects — covered by SST2450
-dotnet_diagnostic.S3453.severity = none # Classes should not have only "private" constructors — covered by SST2451
-dotnet_diagnostic.S3466.severity = none # Optional parameters should be passed to "base" calls — covered by SST2425
-dotnet_diagnostic.S3598.severity = none # One-way "OperationContract" methods should have "void" return type -> replaced by obsolete (WCF)
-dotnet_diagnostic.S3603.severity = none # Methods with "Pure" attribute should return a value — covered by SST2452
-dotnet_diagnostic.S3610.severity = none # Nullable type comparison should not be redundant -> replaced by compiler CS0472
-dotnet_diagnostic.S3903.severity = none # Types should be defined in named namespaces — covered by SST2312
-dotnet_diagnostic.S3923.severity = none # All branches in a conditional structure should not have exactly the same implementation — covered by SST1476
-dotnet_diagnostic.S3926.severity = none # Deserialization methods should be provided for "OptionalField" members -> replaced by obsolete (legacy binary serialization)
-dotnet_diagnostic.S3927.severity = none # Serialization event handlers should be implemented correctly — covered by SST2430
-dotnet_diagnostic.S3981.severity = none # Collection sizes and array length comparisons should make sense — covered by SST1479
-dotnet_diagnostic.S3984.severity = none # Exceptions should not be created without being thrown — covered by SST1480
-dotnet_diagnostic.S4143.severity = none # Collection elements should not be replaced unconditionally — covered by SST1487
-dotnet_diagnostic.S4210.severity = none # Windows Forms entry points should be marked with STAThread -> replaced by SST2706
-dotnet_diagnostic.S4260.severity = none # "ConstructorArgument" parameters should exist in constructors -> replaced by SST2487
-dotnet_diagnostic.S4428.severity = none # "PartCreationPolicyAttribute" should be used with "ExportAttribute" — covered by SST2474
-dotnet_diagnostic.S6507.severity = none # Blocks should not be synchronized on local variables — covered by SST1903
-dotnet_diagnostic.S6677.severity = none # Message template placeholders should be unique — covered by SST2442
-dotnet_diagnostic.S6797.severity = none # Blazor query parameter type should be supported -> replaced by SST2702
-dotnet_diagnostic.S6798.severity = none # [JSInvokable] attribute should only be used on public methods -> replaced by SST2701
-dotnet_diagnostic.S6800.severity = none # Component parameter type should match the route parameter type constraint -> replaced by SST2703
-dotnet_diagnostic.S6930.severity = none # Backslash should be avoided in route templates -> replaced by SST2700
-
-# Minor bugs
-dotnet_diagnostic.S1206.severity = none # "Equals(Object)" and "GetHashCode()" should be overridden in pairs - DUPLICATE CA2218
-dotnet_diagnostic.S1226.severity = none # Method parameters, caught exceptions and foreach variables' initial values should not be ignored
-dotnet_diagnostic.S2183.severity = none # Integral numbers should not be shifted by zero or more than their number of bits-1 — covered by SST1478
-dotnet_diagnostic.S2184.severity = none # Results of integer division should not be assigned to floating point variables — covered by SST1477
-dotnet_diagnostic.S2328.severity = none # "GetHashCode" should not reference mutable fields — covered by SST1482
-dotnet_diagnostic.S2345.severity = none # Flags enumerations should explicitly initialize all their members — covered by SST2303
-dotnet_diagnostic.S2674.severity = none # The length returned from a stream read should be checked — covered by SST2446
-dotnet_diagnostic.S2934.severity = none # Property assignments should not be made for "readonly" fields not constrained to reference types — covered by SST2421
-dotnet_diagnostic.S2955.severity = none # Generic parameters not constrained to reference types should not be compared to "null" -> replaced by compiler CS0019/CS0037
-dotnet_diagnostic.S3363.severity = none # Date and time should not be used as a type for primary keys — covered by SST2475
-dotnet_diagnostic.S3397.severity = none # "base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object" — covered by SST2435
-dotnet_diagnostic.S3456.severity = none # "string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly — covered by PSH1217
-dotnet_diagnostic.S3887.severity = none # Mutable, non-private fields should not be "readonly" — covered by SST2322
-
-# Blocker vulnerabilities
-dotnet_diagnostic.S2115.severity = none # A secure password should be used when connecting to a database -> replaced by SES1203
-dotnet_diagnostic.S2755.severity = none # XML parsers should not be vulnerable to XXE attacks -> replaced by CA3075
-dotnet_diagnostic.S3884.severity = none # "CoSetProxyBlanket" and "CoInitializeSecurity" should not be used -> replaced by obsolete (COM interop security)
-dotnet_diagnostic.S6418.severity = none # Secrets should not be hard-coded — covered by SES1201
-
-# Critical vulnerabilities
-dotnet_diagnostic.S4423.severity = none # Weak SSL/TLS protocols should not be used -> replaced by CA5397/CA5398
-dotnet_diagnostic.S4426.severity = none # Cryptographic keys should be robust -> replaced by CA5385 (RSA) / CA5384 (DSA)
-dotnet_diagnostic.S4433.severity = none # LDAP connections should be authenticated -> replaced by SES1310
-dotnet_diagnostic.S4830.severity = none # Server certificates should be verified during SSL/TLS connections -> replaced by SES1102 or SES1108
-dotnet_diagnostic.S5344.severity = none # Passwords should not be stored in plaintext or with a fast hashing algorithm -> replaced by SES1009
-dotnet_diagnostic.S5445.severity = none # Insecure temporary file creation methods should not be used -> replaced by SES1307
-dotnet_diagnostic.S5542.severity = none # Encryption algorithms should be used with secure mode and padding scheme -> replaced by CA5358
-dotnet_diagnostic.S5547.severity = none # Cipher algorithms should be robust -> replaced by CA5351
-dotnet_diagnostic.S5659.severity = none # JWT should be signed and verified with strong cipher algorithms -> replaced by SES1503
-
-# Major vulnerabilities
-dotnet_diagnostic.S2068.severity = none # Credentials should not be hard-coded -> replaced by SES1201
-dotnet_diagnostic.S2612.severity = none # File permissions should not be set to world-accessible values -> replaced by SES1308
-dotnet_diagnostic.S4211.severity = none # Members should not have conflicting transparency annotations -> replaced by obsolete (Code Access Security)
-dotnet_diagnostic.S4212.severity = none # Serialization constructors should be secured -> replaced by obsolete (Code Access Security)
-dotnet_diagnostic.S6377.severity = none # XML signatures should be validated securely -> replaced by SES1008
-dotnet_diagnostic.S7039.severity = none # Content Security Policies should be restrictive -> replaced by SES1515
-
-# Blocker code smells
-dotnet_diagnostic.S1147.severity = none # Exit methods should not be called — covered by SST2321
-dotnet_diagnostic.S1451.severity = none # Track lack of copyright and license headers
-dotnet_diagnostic.S2178.severity = none # Short-circuit logic should be used in boolean contexts — covered by SST2415
-dotnet_diagnostic.S2187.severity = none # Test classes should contain at least one test case — covered by SST2504
-dotnet_diagnostic.S2306.severity = none # "async" and "await" should not be used as identifiers -> replaced by compiler (contextual keyword)
-dotnet_diagnostic.S2368.severity = none # Public methods should not have multidimensional array parameters — jagged arrays are the chosen layout for hot-path lookup tables
-dotnet_diagnostic.S2387.severity = none # Child class fields should not shadow parent class fields — covered by SST1484
-dotnet_diagnostic.S2437.severity = none # Unnecessary bit operations should not be performed — covered by SST1481
-dotnet_diagnostic.S2699.severity = none # Tests should include assertions -> replaced by SST2500
-dotnet_diagnostic.S2953.severity = none # Methods named "Dispose" should implement "IDisposable.Dispose" — covered by SST2316
-dotnet_diagnostic.S2970.severity = none # Assertions should be complete -> replaced by SST2508
-dotnet_diagnostic.S3060.severity = none # "is" should not be used with "this" -> replaced by SST2327
-dotnet_diagnostic.S3237.severity = none # "value" contextual keyword should be used — covered by SST2429
-dotnet_diagnostic.S3427.severity = none # Method overloads with default parameter values should not overlap — covered by SST2319
-dotnet_diagnostic.S3433.severity = none # Test method signatures should be correct -> replaced by SST2509
-dotnet_diagnostic.S3443.severity = none # Type should not be examined on "System.Type" instances — covered by SST2432
-dotnet_diagnostic.S3875.severity = none # "operator==" should not be overloaded on reference types -> replaced by SST2464
-dotnet_diagnostic.S3877.severity = none # Exceptions should not be thrown from unexpected methods — covered by SST1485
-dotnet_diagnostic.S4462.severity = none # Calls to "async" methods should not be blocking - covered by PSH1315
-dotnet_diagnostic.S6422.severity = none # Calls to "async" methods should not be blocking in Azure Functions — covered by PSH1315
-dotnet_diagnostic.S6424.severity = none # Interfaces for durable entities should satisfy the restrictions -> off: Durable Entity-specific; not used in this library
-
-# Critical code smells
-dotnet_diagnostic.S1006.severity = none # Method overrides should not change parameter defaults — covered by SST2424
-dotnet_diagnostic.S1067.severity = none # Expressions should not be too complex
-dotnet_diagnostic.S1163.severity = none # Exceptions should not be thrown in finally blocks -> replaced by CA2219
-dotnet_diagnostic.S1186.severity = none # Methods should not be empty — covered by SST1438
-dotnet_diagnostic.S121.severity = none # Control structures should use curly braces (kept over SA1503 — Sonar 20ms vs SA1503 50ms) -> replaced by SST1503
-dotnet_diagnostic.S1215.severity = none # "GC.Collect" should not be called — covered by PSH1021
-dotnet_diagnostic.S126.severity = none # "if ... else if" constructs should end with "else" clauses
-dotnet_diagnostic.S131.severity = none # "switch/Select" statements should contain a "default/Case Else" clauses
-dotnet_diagnostic.S134.severity = none # Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
-dotnet_diagnostic.S1541.severity = none # Methods and properties should not be too complex - covered by SST1442
-dotnet_diagnostic.S1699.severity = none # Constructors should only call non-overridable methods — covered by SST1483
-dotnet_diagnostic.S1821.severity = none # "switch" statements should not be nested -> replaced by SST2252
-dotnet_diagnostic.S1944.severity = none # Invalid casts should be avoided -> replaced by compiler CS0030
-dotnet_diagnostic.S1994.severity = none # "for" loop increment clauses should modify the loops' counters — covered by SST2411
-dotnet_diagnostic.S2197.severity = none # Modulus results should not be checked for direct equality — covered by SST2416
-dotnet_diagnostic.S2198.severity = none # Unnecessary mathematical comparisons should not be made -> replaced by SST2489
-dotnet_diagnostic.S2223.severity = none # Non-constant static fields should not be visible - DUPLICATE CA2211
-dotnet_diagnostic.S2290.severity = none # Field-like events should not be virtual -> replaced by SST2456
-dotnet_diagnostic.S2291.severity = none # Overflow checking should not be disabled for "Enumerable.Sum" — covered by SST2457
-dotnet_diagnostic.S2302.severity = none # "nameof" should be used — covered by SST1415
-dotnet_diagnostic.S2330.severity = none # Array covariance should not be used — covered by SST2434
-dotnet_diagnostic.S2339.severity = none # Public constant members should not be used — covered by SST2311
-dotnet_diagnostic.S2346.severity = none # Flags enumerations zero-value members should be named "None" - DUPLICATE CA1008
-dotnet_diagnostic.S2360.severity = none # Optional parameters should not be used — conflicts with SST2433, which owns caller-info parameters requiring a default
-dotnet_diagnostic.S2365.severity = none # Properties should not make collection or array copies — covered by PSH1017
-dotnet_diagnostic.S2479.severity = none # Whitespace and control characters in string literals should be explicit — covered by SST1192
-dotnet_diagnostic.S2692.severity = none # "IndexOf" checks should not be for positive numbers — covered by SST2420
-dotnet_diagnostic.S2696.severity = none # Instance members should not write to "static" fields -> replaced by SST2402
-dotnet_diagnostic.S2701.severity = none # Literal boolean values should not be used in assertions — covered by SST2503
-dotnet_diagnostic.S3215.severity = none # "interface" instances should not be cast to concrete types -> deliberately unenforced, same reason as SST2326
-dotnet_diagnostic.S3216.severity = none # "ConfigureAwait(false)" should be used -> replaced by CA2007
-dotnet_diagnostic.S3217.severity = none # "Explicit" conversions of "foreach" loops should not be used — covered by SST2225
-dotnet_diagnostic.S3218.severity = none # Inner class members should not shadow outer class "static" or type members — covered by SST1484
-dotnet_diagnostic.S3265.severity = none # Non-flags enums should not be used in bitwise operations — covered by SST2458
-dotnet_diagnostic.S3353.severity = none # Unchanged variables should be marked as "const" — covered by PSH1402
-dotnet_diagnostic.S3447.severity = none # "[Optional]" should not be used on "ref" or "out" parameters — covered by SST2459
-dotnet_diagnostic.S3451.severity = none # "[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant — covered by SST2460
-dotnet_diagnostic.S3600.severity = none # "params" should not be introduced on overrides — covered by SST2426
-dotnet_diagnostic.S3776.severity = none # Cognitive Complexity of methods should not be too high - covered by SST1443
-dotnet_diagnostic.S3871.severity = none # Exception types should be "public" -> replaced by CA1064
-dotnet_diagnostic.S3874.severity = none # "out" and "ref" parameters — repo idiom is TryX(..., out T value)
-dotnet_diagnostic.S3904.severity = none # Assemblies should have version information -> replaced by obsolete (SDK supplies assembly version)
-dotnet_diagnostic.S3937.severity = none # Number patterns should be regular — covered by SST1119
-dotnet_diagnostic.S3972.severity = none # Conditionals should start on new lines — covered by SST1146
-dotnet_diagnostic.S3973.severity = none # A conditionally executed single line should be denoted by indentation -> replaced by SST1503
-dotnet_diagnostic.S3998.severity = none # Threads should not lock on objects with weak identity -> replaced by SST1902
-dotnet_diagnostic.S4000.severity = none # Pointers to unmanaged memory should not be visible -> replaced by SST2328
-dotnet_diagnostic.S4015.severity = none # Inherited member visibility should not be decreased — covered by SST2462
-dotnet_diagnostic.S4019.severity = none # Base class methods should not be hidden — covered by SST2427
-dotnet_diagnostic.S4025.severity = none # Child class fields should not differ from parent class fields only by capitalization — covered by SST2463
-dotnet_diagnostic.S4039.severity = none # Interface methods should be callable by derived types - DUPLICATE CA1033
-dotnet_diagnostic.S4487.severity = none # Unread "private" fields should be removed
-dotnet_diagnostic.S4524.severity = none # "default" clauses should be first or last — covered by SST1219
-dotnet_diagnostic.S4635.severity = none # Start index should be used instead of calling Substring — covered by PSH1218
-dotnet_diagnostic.S5034.severity = none # "ValueTask" should be consumed correctly — covered by PSH1316
-dotnet_diagnostic.S6967.severity = none # ModelState.IsValid should be called in controller actions -> off: ASP.NET MVC-specific; no controllers in this library
-dotnet_diagnostic.S8367.severity = none # Identifiers should not conflict with the C# 14 "field" contextual keyword - the C# 14 compiler reports this: CS9273 (error) for a local named field in an accessor, CS9258 (warning) for a rebinding read
-dotnet_diagnostic.S8368.severity = none # Identifiers should not conflict with the C# 14 "extension" contextual keyword - the C# 14 compiler reports this as CS9306, and SST1300 already flags the lowercase type name
-dotnet_diagnostic.S8380.severity = none # Return types named "partial" should be escaped with "@" - the compiler reports this as CS8981, and SST1300 already flags the lowercase type name
-dotnet_diagnostic.S8381.severity = none # "scoped" should be escaped when used as an identifier or type name in parenthesized lambda parameter lists -> replaced by compiler
-dotnet_diagnostic.S927.severity = none # Parameter names should match base declaration and other partial definitions - DUPLICATE CA1725
-
-# Major code smells
-dotnet_diagnostic.S103.severity = none # Lines should not be too long — covered by SST1521
-dotnet_diagnostic.S104.severity = none # Files should not have too many lines of code — covered by SST1522
-dotnet_diagnostic.S106.severity = none # Covered by SST1449 (canonical)
-dotnet_diagnostic.S1066.severity = none # Mergeable "if" statements should be combined — covered by SST2013
-dotnet_diagnostic.S107.severity = none # Methods should not have too many parameters — covered by SST1472
-dotnet_diagnostic.S108.severity = none # Nested blocks of code should not be left empty — covered by SST1439
-dotnet_diagnostic.S109.severity = none # Magic numbers should not be used — covered by SST1471
-dotnet_diagnostic.S110.severity = none # Inheritance tree of classes should not be too deep — covered by SST1446
-dotnet_diagnostic.S1110.severity = none # Redundant pairs of parentheses should be removed — covered by SST1459
-dotnet_diagnostic.S1117.severity = none # Local variables should not shadow class fields or properties — covered by SST1484
-dotnet_diagnostic.S1118.severity = none # Utility classes should not have public constructors - DUPLICATE CA1052
-dotnet_diagnostic.S112.severity = none # General or reserved exceptions should never be thrown — covered by SST2409
-dotnet_diagnostic.S1121.severity = none # Assignments should not be made from within sub-expressions — covered by SST1187
-dotnet_diagnostic.S1123.severity = none # "Obsolete" attributes should include explanations — covered by SST2308
-dotnet_diagnostic.S1134.severity = none # Track uses of "FIXME" tags -> off: TODO comment tracker; not enforced here
-dotnet_diagnostic.S1144.severity = none # Covered by SST1440 (canonical)
-dotnet_diagnostic.S1151.severity = none # "switch case" clauses should not have too many lines of code — covered by SST1524
-dotnet_diagnostic.S1168.severity = none # Empty arrays and collections should be returned instead of null — covered by SST2306
-dotnet_diagnostic.S1172.severity = none # Unused method parameters should be removed — covered by SST1461
-dotnet_diagnostic.S1200.severity = none # Classes should not be coupled to too many other classes
-dotnet_diagnostic.S122.severity = none # Statements should be on separate lines — covered by SST1107
-dotnet_diagnostic.S125.severity = none # Sections of code should not be commented out — covered by SST1148
-dotnet_diagnostic.S127.severity = none # "for" loop stop conditions should be invariant — covered by SST2465
-dotnet_diagnostic.S138.severity = none # Functions should not have too many lines of code — covered by SST1523
-dotnet_diagnostic.S1479.severity = none # "switch" statements with many "case" clauses — covered by SST1423
-dotnet_diagnostic.S1607.severity = none # Tests should not be ignored -> off: ignored-test tracker; not enforced here
-dotnet_diagnostic.S1696.severity = none # NullReferenceException should not be caught — covered by SST2401
-dotnet_diagnostic.S1854.severity = none # Unused assignments should be removed - DUPLICATE IDE0059
-dotnet_diagnostic.S1871.severity = none # Two branches in a conditional structure should not have exactly the same implementation — covered by SST2414
-dotnet_diagnostic.S2139.severity = none # Exceptions should be either logged or rethrown but not both -> replaced by SST2488
-dotnet_diagnostic.S2166.severity = none # Classes named like "Exception" should extend "Exception" or a subclass - DUPLICATE CA1710
-dotnet_diagnostic.S2234.severity = none # Arguments should be passed in the same order as the method parameters -> replaced by SST2400
-dotnet_diagnostic.S2326.severity = none # Covered by SST1452 (canonical)
-dotnet_diagnostic.S2327.severity = none # "try" statements with identical "catch" and/or "finally" blocks should be merged -> replaced by SST2490
-dotnet_diagnostic.S2357.severity = none # Fields should be private — duplicate of SST1401 (canonical); fields intentionally exposed (e.g. public test fields for reflection) already carry per-site SST1401 suppressions
-dotnet_diagnostic.S2372.severity = none # Exceptions should not be thrown from property getters — covered by SST1485
-dotnet_diagnostic.S2376.severity = none # Write-only properties should not be used — covered by SST1421
-dotnet_diagnostic.S2629.severity = none # Logging templates should be constant -> replaced by CA2254
-dotnet_diagnostic.S2681.severity = none # Multiline blocks should be enclosed in curly braces — covered by SST1503
-dotnet_diagnostic.S2743.severity = none # Static fields should not be used in generic types - DUPLICATE CA1000 — covered by SST1431
-dotnet_diagnostic.S2925.severity = none # "Thread.Sleep" should not be used in tests — covered by SST2506
-dotnet_diagnostic.S2933.severity = none # Fields that are only assigned in the constructor should be "readonly" - DUPLICATE IDE0044
-dotnet_diagnostic.S2971.severity = none # LINQ expressions should be simplified — covered by PSH1101/PSH1102
-dotnet_diagnostic.S3010.severity = none # Static fields should not be updated in constructors — covered by SST2402
-dotnet_diagnostic.S3011.severity = none # Reflection should not be used to increase accessibility of classes, methods, or fields -> replaced by SES1406
-dotnet_diagnostic.S3059.severity = none # Types should not have members with visibility set higher than the type's visibility
-dotnet_diagnostic.S3063.severity = none # "StringBuilder" data should be used — covered by SST2408
-dotnet_diagnostic.S3169.severity = none # Multiple "OrderBy" calls should not be used — covered by PSH1108
-dotnet_diagnostic.S3246.severity = none # Generic type parameters should be co/contravariant when possible -> off: low-precision variance suggestion; not enforced
-dotnet_diagnostic.S3262.severity = none # "params" should be used on overrides — covered by SST2426
-dotnet_diagnostic.S3264.severity = none # Events should be invoked — covered by SST2407
-dotnet_diagnostic.S3358.severity = none # Ternary operators should not be nested — covered by SST1147
-dotnet_diagnostic.S3366.severity = none # "this" should not be exposed from constructors — covered by SST2403
-dotnet_diagnostic.S3415.severity = none # Assertion arguments should be passed in the correct order — covered by SST2502
-dotnet_diagnostic.S3431.severity = none # "[ExpectedException]" should not be used — covered by SST2507
-dotnet_diagnostic.S3442.severity = none # "abstract" classes should not have "public" constructors — covered by SST1428
-dotnet_diagnostic.S3445.severity = none # Exceptions should not be explicitly rethrown — covered by SST1430
-dotnet_diagnostic.S3457.severity = none # Composite format strings should be used correctly — covered by SST1454
-dotnet_diagnostic.S3597.severity = none # "ServiceContract" and "OperationContract" attributes should be used together -> replaced by obsolete (WCF)
-dotnet_diagnostic.S3880.severity = none # Finalizers should not be empty — covered by PSH1002
-dotnet_diagnostic.S3881.severity = none # "IDisposable" should be implemented correctly — covered by SST2300
-dotnet_diagnostic.S3885.severity = none # "Assembly.Load" should be used -> replaced by SST2486
-dotnet_diagnostic.S3898.severity = none # Covered by PSH1005 (canonical)
-dotnet_diagnostic.S3902.severity = none # Covered by PSH1404 (canonical)
-dotnet_diagnostic.S3906.severity = none # Event Handlers should have the correct signature — covered by SST2304
-dotnet_diagnostic.S3908.severity = none # Generic event handlers should be used -> replaced by SST2304
-dotnet_diagnostic.S3909.severity = none # Collections should implement the generic interface -> replaced by CA1010
-dotnet_diagnostic.S3925.severity = none # "ISerializable" should be implemented correctly - BinaryFormatter / ISerializable serialization is obsoleted (SYSLIB0050/0051) in modern .NET; we do not opt into legacy serialization for any exception type
-dotnet_diagnostic.S3928.severity = none # Parameter names used into ArgumentException constructors should match an existing one - DUPLICATE CA2208
-dotnet_diagnostic.S3956.severity = none # "Generic.List" instances should not be part of public APIs
-dotnet_diagnostic.S3971.severity = none # "GC.SuppressFinalize" should not be called — conflicts with PSH1008, which owns the pointless-SuppressFinalize direction and exempts unsealed types
-dotnet_diagnostic.S3990.severity = none # Assemblies should be marked as CLS compliant -> replaced by CA1014
-dotnet_diagnostic.S3992.severity = none # Assemblies should explicitly specify COM visibility -> replaced by CA1017
-dotnet_diagnostic.S3993.severity = none # Custom attributes should be marked with "System.AttributeUsageAttribute" -> replaced by CA1018
-dotnet_diagnostic.S3994.severity = none # URI Parameters should not be strings
-dotnet_diagnostic.S3995.severity = none # URI return values should not be strings
-dotnet_diagnostic.S3996.severity = none # URI properties should not be strings
-dotnet_diagnostic.S3997.severity = none # String URI overloads should call "System.Uri" overloads -> replaced by CA1054/CA1056/CA1057
-dotnet_diagnostic.S4002.severity = none # Disposable types should declare finalizers — covered by SST2317
-dotnet_diagnostic.S4004.severity = none # Collection properties should be readonly — covered by SST2305
-dotnet_diagnostic.S4005.severity = none # "System.Uri" arguments should be used instead of strings
-dotnet_diagnostic.S4016.severity = none # Enumeration members should not be named "Reserved" -> replaced by CA1700
-dotnet_diagnostic.S4017.severity = none # Method signatures should not contain nested generic types
-dotnet_diagnostic.S4035.severity = none # Classes implementing "IEquatable<T>" should be sealed — covered by SST2301
-dotnet_diagnostic.S4050.severity = none # Operators should be overloaded consistently — covered by SST2302
-dotnet_diagnostic.S4055.severity = none # Literals should not be passed as localized parameters
-dotnet_diagnostic.S4057.severity = none # Locales should be set for data types -> replaced by obsolete
-dotnet_diagnostic.S4059.severity = none # Property names should not match get methods - DUPLICATE CA1721
-dotnet_diagnostic.S4070.severity = none # Non-flags enums should not be marked with "FlagsAttribute" — covered by SST2303
-dotnet_diagnostic.S4144.severity = none # Methods should not have identical implementations — covered by SST2318
-dotnet_diagnostic.S4200.severity = none # Native methods should be wrapped -> replaced by CA1401
-dotnet_diagnostic.S4214.severity = none # "P/Invoke" methods should not be visible - DUPLICATE CA1401
-dotnet_diagnostic.S4220.severity = none # Events should have proper arguments — covered by SST2436
-dotnet_diagnostic.S4456.severity = none # Parameter validation in yielding methods should be wrapped — covered by SST2404
-dotnet_diagnostic.S4457.severity = none # Parameter validation in "async"/"await" methods should be wrapped — covered by SST2325
-dotnet_diagnostic.S4545.severity = none # "DebuggerDisplayAttribute" strings should reference existing members — covered by SST2405
-dotnet_diagnostic.S4581.severity = none # "new Guid()" should not be used — covered by SST2012
-dotnet_diagnostic.S6354.severity = none # Use a testable date/time provider — covered by SST2010
-dotnet_diagnostic.S6419.severity = none # Azure Functions should be stateless -> off: Azure Functions-specific; not used in this library
-dotnet_diagnostic.S6420.severity = none # Client instances should not be recreated on each Azure Function invocation — covered by PSH1418
-dotnet_diagnostic.S6421.severity = none # Azure Functions should use Structured Error Handling -> off: Azure Functions-specific; not used in this library
-dotnet_diagnostic.S6423.severity = none # Azure Functions should log all failures -> off: Azure Functions-specific; not used in this library
-dotnet_diagnostic.S6561.severity = none # Avoid using "DateTime.Now" for benchmarking or timing operations — covered by PSH1408
-dotnet_diagnostic.S6562.severity = none # Covered by SST1451 (canonical)
-dotnet_diagnostic.S6563.severity = none # Use UTC when recording DateTime instants — covered by SST2011
-dotnet_diagnostic.S6566.severity = none # Use "DateTimeOffset" instead of "DateTime" — covered by SST2016
-dotnet_diagnostic.S6575.severity = none # Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter" -> replaced by PSH1419
-dotnet_diagnostic.S6580.severity = none # Use a format provider when parsing date and time - DUPLICATE CA1305
-dotnet_diagnostic.S6673.severity = none # Log message template placeholders should be in the right order — covered by SST2440
-dotnet_diagnostic.S6802.severity = none # Using lambda expressions in loops should be avoided in Blazor markup section -> replaced by PSH1600
-dotnet_diagnostic.S6803.severity = none # Parameters with SupplyParameterFromQuery attribute should be used only in routable components -> off: Blazor-specific; no Blazor surface in this library
-dotnet_diagnostic.S6931.severity = none # ASP.NET controller actions should not have a route template starting with "/" -> off: ASP.NET MVC-specific; no controllers in this library
-dotnet_diagnostic.S6932.severity = none # Use model binding instead of reading raw request data -> off: ASP.NET MVC-specific; no controllers in this library
-dotnet_diagnostic.S6934.severity = none # A Route attribute should be added to the controller when a route template is specified at the action level -> off: ASP.NET MVC-specific; no controllers in this library
-dotnet_diagnostic.S6960.severity = none # Controllers should not have mixed responsibilities -> off: ASP.NET MVC-specific; no controllers in this library
-dotnet_diagnostic.S6961.severity = none # API Controllers should derive from ControllerBase instead of Controller -> off: ASP.NET MVC-specific; no controllers in this library
-dotnet_diagnostic.S6962.severity = none # You should pool HTTP connections with HttpClientFactory — covered by PSH1418
-dotnet_diagnostic.S6964.severity = none # Value type property used as input in a controller action should be nullable, required or annotated with the JsonRequiredAttribute to avoid under-posting. -> replaced by SST2705 (opt-in)
-dotnet_diagnostic.S6965.severity = none # REST API actions should be annotated with an HTTP verb attribute -> replaced by SST2704
-dotnet_diagnostic.S6966.severity = none # Awaitable method should be used — covered by PSH1313
-dotnet_diagnostic.S6968.severity = none # Actions that return a value should be annotated with ProducesResponseTypeAttribute containing the return type -> off: ASP.NET MVC-specific; no controllers in this library
-dotnet_diagnostic.S881.severity = none # Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression — covered by SST2015
-dotnet_diagnostic.S907.severity = none # "goto" statement should not be used — covered by SST2014
-
-# Minor code smells
-dotnet_diagnostic.S100.severity = none # Methods and properties should be named in PascalCase — covered by SST1300
-dotnet_diagnostic.S101.severity = none # Types should be named in PascalCase — covered by SST1300
-dotnet_diagnostic.S105.severity = none # Tabulation characters should not be used — covered by SST1027
-dotnet_diagnostic.S1104.severity = none # Fields should not have public accessibility - DUPLICATE CA1051
-dotnet_diagnostic.S1109.severity = none # A close curly brace should be located at the beginning of a line — covered by SST1500
-dotnet_diagnostic.S1116.severity = none # Empty statements should be removed - DUPLICATE SA1106
-dotnet_diagnostic.S1125.severity = none # Boolean literals should not be redundant — covered by SST1182
-dotnet_diagnostic.S1128.severity = none # Covered by SST1445 (canonical)
-dotnet_diagnostic.S113.severity = none # Files should end with a newline
-dotnet_diagnostic.S1155.severity = none # "Any()" should be used to test for emptiness — covered by PSH1119
-dotnet_diagnostic.S1185.severity = none # Overriding members should do more than simply call the same member in the base class - DUPLICATE RCS1132
-dotnet_diagnostic.S1192.severity = none # String literals should not be duplicated — covered by SST1486
-dotnet_diagnostic.S1199.severity = none # Nested code blocks should not be used — covered by SST1138
-dotnet_diagnostic.S1210.severity = none # "Equals" and the comparison operators should be overridden when implementing "IComparable" - DUPLICATE CA1036
-dotnet_diagnostic.S1227.severity = none # break statements should not be used except for switch cases
-dotnet_diagnostic.S1264.severity = none # A "while" loop should be used instead of a "for" loop — covered by SST2245
-dotnet_diagnostic.S1301.severity = none # "switch" statements should have at least 3 "case" clauses
-dotnet_diagnostic.S1312.severity = none # Logger fields should be "private static readonly"
-dotnet_diagnostic.S1449.severity = none # Culture should be specified for "string" operations — covered by PSH1207
-dotnet_diagnostic.S1450.severity = none # Private fields only used as local variables in methods should become local variables — covered by SST1422
-dotnet_diagnostic.S1481.severity = none # Unused local variables should be removed — covered by SST1497
-dotnet_diagnostic.S1643.severity = none # Covered by PSH1206 (canonical)
-dotnet_diagnostic.S1659.severity = none # Multiple variables should not be declared on the same line — covered by SST1132
-dotnet_diagnostic.S1694.severity = none # An abstract class should have both abstract and concrete methods — covered by SST2323
-dotnet_diagnostic.S1698.severity = none # "==" should not be used when "Equals" is overridden — covered by SST1495
-dotnet_diagnostic.S1858.severity = none # "ToString()" calls should not be redundant — covered by PSH1211
-dotnet_diagnostic.S1905.severity = none # Redundant casts should not be used - DUPLICATE IDE0004 — covered by SST1175
-dotnet_diagnostic.S1939.severity = none # Inheritance list should not be redundant — covered by SST1490 and SST1177
-dotnet_diagnostic.S1940.severity = none # Boolean checks should not be inverted — covered by SST1172
-dotnet_diagnostic.S2094.severity = none # Classes should not be empty — covered by SST1436
-dotnet_diagnostic.S2148.severity = none # Underscores should be used to make large numbers readable — covered by SST1191
-dotnet_diagnostic.S2156.severity = none # "sealed" classes should not have "protected" members — covered by SST1427
-dotnet_diagnostic.S2219.severity = none # Runtime type checking should be simplified — covered by SST2007
-dotnet_diagnostic.S2221.severity = none # "Exception" should not be caught
-dotnet_diagnostic.S2292.severity = none # Trivial properties should be auto-implemented — covered by SST1420
-dotnet_diagnostic.S2325.severity = none # Methods and properties that don't access instance data should be static - DUPLICATE CA1822
-dotnet_diagnostic.S2333.severity = none # Redundant modifiers should not be used — covered by SST1419/SST1491
-dotnet_diagnostic.S2342.severity = none # Enumeration types should comply with a naming convention — covered by SST1319
-dotnet_diagnostic.S2344.severity = none # Enumeration type names should not have "Flags" or "Enum" suffixes - DUPLICATE CA1711
-dotnet_diagnostic.S2386.severity = none # Mutable fields should not be "public static" — covered by SST1499
-dotnet_diagnostic.S2486.severity = none # Generic exceptions should not be ignored — covered by SST1429
-dotnet_diagnostic.S2737.severity = none # "catch" clauses should do more than rethrow — covered by SST1470
-dotnet_diagnostic.S2760.severity = none # Sequential tests should not check the same condition — covered by SST1475
-dotnet_diagnostic.S3052.severity = none # Covered by PSH1403 (canonical)
-dotnet_diagnostic.S3220.severity = none # Method calls should not resolve ambiguously to overloads with "params" — covered by SST2467
-dotnet_diagnostic.S3234.severity = none # Covered by PSH1008 (canonical)
-dotnet_diagnostic.S3235.severity = none # Redundant parentheses should not be used — covered by SST1459
-dotnet_diagnostic.S3236.severity = none # Covered by SST1448 (canonical)
-dotnet_diagnostic.S3240.severity = none # The simplest possible condition syntax should be used - duplicate of SST1198
-dotnet_diagnostic.S3241.severity = none # Methods should not return values that are never used -> off: needs whole-program analysis; not enforced here
-dotnet_diagnostic.S3242.severity = none # Method parameters should be declared with base types
-dotnet_diagnostic.S3247.severity = none # Duplicate casts should not be made — covered by SST1175
-dotnet_diagnostic.S3251.severity = none # Implementations should be provided for "partial" methods — covered by SST2468
-dotnet_diagnostic.S3253.severity = none # Constructor and destructor declarations should not be redundant — covered by SST1433
-dotnet_diagnostic.S3254.severity = none # Default parameter values should not be passed as arguments — covered by SST1494
-dotnet_diagnostic.S3256.severity = none # "string.IsNullOrEmpty" should be used — covered by PSH1204 (style configurable)
-dotnet_diagnostic.S3257.severity = none # Declarations and initializations should be as concise as possible -> replaced by SST2202
-dotnet_diagnostic.S3260.severity = none # Non-derived "private" classes and records should be "sealed" — covered by PSH1411
-dotnet_diagnostic.S3261.severity = none # Namespaces should not be empty — covered by SST1435
-dotnet_diagnostic.S3267.severity = none # Loops should be simplified with "LINQ" expressions
-dotnet_diagnostic.S3376.severity = none # Attribute, EventArgs, and Exception type names should end with the type being extended - DUPLICATE CA1710
-dotnet_diagnostic.S3398.severity = none # "private" methods called only by inner classes should be moved to those classes — covered by SST1498
-dotnet_diagnostic.S3400.severity = none # Methods should not return constants — covered by SST1493
-dotnet_diagnostic.S3416.severity = none # Loggers should be named for their enclosing types — covered by SST2443
-dotnet_diagnostic.S3440.severity = none # Variables should not be checked against the values they're about to be assigned — covered by SST1492
-dotnet_diagnostic.S3441.severity = none # Redundant property names should be omitted in anonymous classes — covered by SST1173
-dotnet_diagnostic.S3444.severity = none # Interfaces should not simply inherit from base interfaces with colliding members — covered by SST2320
-dotnet_diagnostic.S3450.severity = none # Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]" -> replaced by obsolete (legacy DefaultParameterValue)
-dotnet_diagnostic.S3458.severity = none # Empty "case" clauses that fall through to the "default" should be omitted — covered by SST1466
-dotnet_diagnostic.S3459.severity = none # Unassigned members should be removed - the compiler reports this as CS0649; the rule only ever fires on private never-assigned fields
-dotnet_diagnostic.S3532.severity = none # Empty "default" clauses should be removed — covered by SST1179
-dotnet_diagnostic.S3604.severity = none # Member initializer values should not be redundant — covered by PSH1403
-dotnet_diagnostic.S3626.severity = none # Jump statements should not be redundant — covered by SST1174
-dotnet_diagnostic.S3717.severity = none # Track use of "NotImplementedException" -> replaced by SST2485
-dotnet_diagnostic.S3872.severity = none # Parameter names should not duplicate the names of their methods -> replaced by SST1320
-dotnet_diagnostic.S3876.severity = none # Strings or integral types should be used for indexers -> replaced by CA1043
-dotnet_diagnostic.S3878.severity = none # Arrays should not be created for params parameters — covered by PSH1018
-dotnet_diagnostic.S3897.severity = none # Classes that provide "Equals(<T>)" should implement "IEquatable<T>" -> replaced by CA1067
-dotnet_diagnostic.S3962.severity = none # Covered by PSH1402 (canonical)
-dotnet_diagnostic.S3963.severity = none # "static" fields should be initialized inline - DUPLICATE CA1810
-dotnet_diagnostic.S3967.severity = none # Multidimensional arrays should not be used - DUPLICATE CA1814
-dotnet_diagnostic.S4018.severity = none # All type parameters should be used in the parameter list to enable type inference — covered by SST2307
-dotnet_diagnostic.S4022.severity = none # Enumerations should have "Int32" storage — covered by SST2313
-dotnet_diagnostic.S4023.severity = none # Interfaces should not be empty — covered by SST1437
-dotnet_diagnostic.S4026.severity = none # Assemblies should be marked with "NeutralResourcesLanguageAttribute" -> replaced by CA1824
-dotnet_diagnostic.S4027.severity = none # Exceptions should provide standard constructors — covered by SST1488
-dotnet_diagnostic.S4040.severity = none # Strings should be normalized to uppercase - DUPLICATE CA1308
-dotnet_diagnostic.S4041.severity = none # Type names should not match namespaces - DUPLICATE CA1724
-dotnet_diagnostic.S4047.severity = none # Generics should be used when appropriate -> off: fuzzy prefer-generics suggestion; not enforced
-dotnet_diagnostic.S4049.severity = none # Properties should be preferred - DUPLICATE CA1024
-dotnet_diagnostic.S4052.severity = none # Types should not extend outdated base types -> replaced by obsolete
-dotnet_diagnostic.S4056.severity = none # Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used - DUPLICATE CA1305
-dotnet_diagnostic.S4058.severity = none # Covered by PSH1207 (canonical)
-dotnet_diagnostic.S4060.severity = none # Non-abstract attributes should be sealed - DUPLICATE CA1813
-dotnet_diagnostic.S4061.severity = none # "params" should be used instead of "varargs" -> replaced by obsolete (__arglist varargs)
-dotnet_diagnostic.S4069.severity = none # Operator overloads should have named alternatives - DUPLICATE CA2225
-dotnet_diagnostic.S4136.severity = none # Method overloads should be grouped together — covered by SST1218
-dotnet_diagnostic.S4201.severity = none # Null checks should not be combined with "is" operator checks — covered by SST2018
-dotnet_diagnostic.S4225.severity = none # Extension methods should not extend "object" — covered by SST1706
-dotnet_diagnostic.S4226.severity = none # Extensions should be in separate namespaces
-dotnet_diagnostic.S4261.severity = none # Methods should be named according to their synchronicities - Async suffix not used
-dotnet_diagnostic.S4663.severity = none # Covered by SST1120 (canonical)
-dotnet_diagnostic.S6513.severity = none # "ExcludeFromCodeCoverage" attributes should include a justification - not available on net462 and older TFMs
-dotnet_diagnostic.S6585.severity = none # Don't hardcode the format when turning dates and times to strings — covered by SST2445
-dotnet_diagnostic.S6588.severity = none # Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch — covered by PSH1413
-dotnet_diagnostic.S6594.severity = none # Covered by PSH1406 (canonical)
-dotnet_diagnostic.S6602.severity = none # Covered by PSH1110 (canonical)
-dotnet_diagnostic.S6603.severity = none # Covered by PSH1110 (canonical)
-dotnet_diagnostic.S6605.severity = none # Covered by PSH1110 (canonical)
-dotnet_diagnostic.S6607.severity = none # The collection should be filtered before sorting — covered by PSH1107
-dotnet_diagnostic.S6608.severity = none # Covered by PSH1106 (canonical)
-dotnet_diagnostic.S6609.severity = none # "Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods — covered by PSH1122
-dotnet_diagnostic.S6610.severity = none # Covered by PSH1201 (canonical)
-dotnet_diagnostic.S6612.severity = none # The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods — covered by PSH1006
-dotnet_diagnostic.S6613.severity = none # "First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods — covered by PSH1124
-dotnet_diagnostic.S6617.severity = none # Covered by PSH1111 (canonical)
-dotnet_diagnostic.S6618.severity = none # "string.Create" should be used instead of "FormattableString" — covered by PSH1209
-dotnet_diagnostic.S6664.severity = none # The code block contains too many logging calls -> off: fuzzy too-many-logging-calls metric; not enforced
-dotnet_diagnostic.S6667.severity = none # Logging in a catch clause should pass the caught exception as a parameter. — covered by SST2438
-dotnet_diagnostic.S6668.severity = none # Logging arguments should be passed to the correct parameter — covered by SST2439
-dotnet_diagnostic.S6669.severity = none # Logger field or property name should comply with a naming convention -> replaced by SST2601
-dotnet_diagnostic.S6670.severity = none # "Trace.Write" and "Trace.WriteLine" should not be used — covered by SST2600
-dotnet_diagnostic.S6672.severity = none # Generic logger injection should match enclosing type — covered by SST2443
-dotnet_diagnostic.S6675.severity = none # "Trace.WriteLineIf" should not be used with "TraceSwitch" levels -> off: niche TraceSwitch misuse; not enforced here
-dotnet_diagnostic.S6678.severity = none # Use PascalCase for named placeholders -> replaced by CA1727
-dotnet_diagnostic.S818.severity = none # Literal suffixes should be upper case — covered by SST2244
-
-# Informational code smells
-dotnet_diagnostic.S1133.severity = none # Deprecated code should be removed — covered by SST2310
-dotnet_diagnostic.S1135.severity = none # Track uses of "TODO" tags -> off: FIXME comment tracker; not enforced here
-dotnet_diagnostic.S1309.severity = none # Track uses of in-source issue suppressions
-
-# Uncategorized
-dotnet_diagnostic.S9999-cpd.severity = error # Copy-paste token calculator
-dotnet_diagnostic.S9999-log.severity = error # Log generator
-dotnet_diagnostic.S9999-metadata.severity = error # File metadata generator
-dotnet_diagnostic.S9999-metrics.severity = error # Metrics calculator
-dotnet_diagnostic.S9999-symbolRef.severity = error # Symbol reference calculator
-dotnet_diagnostic.S9999-telemetry.severity = error # Telemetry generator
-dotnet_diagnostic.S9999-testMethodDeclaration.severity = error # Test method declarations generator
-dotnet_diagnostic.S9999-token-type.severity = error # Token type calculator
-dotnet_diagnostic.S9999-warning.severity = error # Analysis Warning generator
-
-# Critical security hotspots
-dotnet_diagnostic.S2245.severity = none # Using pseudorandom number generators (PRNGs) is security-sensitive - DUPLICATE CA5394
-dotnet_diagnostic.S2257.severity = none # Using non-standard cryptographic algorithms is security-sensitive -> replaced by SES1007
-dotnet_diagnostic.S4502.severity = none # Disabling CSRF protections is security-sensitive -> replaced by in-box ASP.NET antiforgery analyzer
-dotnet_diagnostic.S4790.severity = none # Using weak hashing algorithms is security-sensitive -> replaced by CA5350/CA5351
-dotnet_diagnostic.S4792.severity = none # Configuring loggers is security-sensitive -> off: logging-configuration audit hotspot; not enforced here
-dotnet_diagnostic.S5042.severity = none # Expanding archive files without controlling resource consumption is security-sensitive -> off: unbounded decompression; needs taint analysis, out of scope
-dotnet_diagnostic.S5332.severity = none # Using clear-text protocols is security-sensitive -> replaced by SES1106
-dotnet_diagnostic.S5443.severity = none # Using publicly writable directories is security-sensitive -> replaced by SES1308
-
-# Major security hotspots
-dotnet_diagnostic.S1313.severity = none # Using hardcoded IP addresses is security-sensitive -> off: hardcoded-IP heuristic; too noisy to enforce
-dotnet_diagnostic.S2077.severity = none # Formatting SQL queries is security-sensitive -> replaced by CA2100
-dotnet_diagnostic.S5693.severity = none # Allowing requests with excessive content length is security-sensitive -> replaced by SES1505
-dotnet_diagnostic.S5753.severity = none # Disabling ASP.NET "Request Validation" feature is security-sensitive -> replaced by obsolete (legacy ASP.NET request validation)
-dotnet_diagnostic.S5766.severity = none # Creating Serializable objects without data validation checks is security-sensitive -> off: legacy BinaryFormatter deserialization; obsolete path, not used here
-dotnet_diagnostic.S6444.severity = none # Not specifying a timeout for regular expressions is security-sensitive -> replaced by SES1509
-dotnet_diagnostic.S6640.severity = none # Using unsafe code blocks is security-sensitive -> off: unsafe-code audit; not enforced here
-
-# Minor security hotspots
-dotnet_diagnostic.S2092.severity = none # Creating cookies without the "secure" flag is security-sensitive -> replaced by CA5382
-dotnet_diagnostic.S3330.severity = none # Creating cookies without the "HttpOnly" flag is security-sensitive -> replaced by CA5383
-dotnet_diagnostic.S4507.severity = none # Delivering code in production with debug features activated is security-sensitive -> off: debug features in production; partly covered by SES1506, rest not enforced
-dotnet_diagnostic.S5122.severity = none # Having a permissive Cross-Origin Resource Sharing policy is security-sensitive -> replaced by SES1501
+dotnet_diagnostic.S3267.severity = none # asks for LINQ in place of a loop, which costs an allocation
+dotnet_diagnostic.S8969.severity = none # nullability inference is inconsistent across the target frameworks built here
 
 #############################################
 # JetBrains ReSharper / Rider Inspections
 #############################################
-# Mirrors the CA / SA / RCS choices above for Rider and ReSharper users. Only
+# Mirrors the CA / SST / PSH choices above for Rider and ReSharper users. Only
 # inspections with a clear mapping to our Roslyn analyzer rules are listed;
 # every other ReSharper inspection keeps its default severity. The goal is to
 # avoid Rider double-reporting things the Roslyn analyzers already catch and
 # to keep IDE severities in sync with CI-enforced severities.
 
 ###################
-# ReSharper - Layout / Formatting (covered by StyleCop SA)
+# ReSharper - Layout / Formatting (covered by the spacing and layout rules)
 ###################
-resharper_redundant_linebreak_highlighting = none # covered by SA layout rules
-resharper_missing_linebreak_highlighting = none # covered by SA layout rules
-resharper_bad_empty_braces_line_breaks_highlighting = none # covered by SA1500
+resharper_redundant_linebreak_highlighting = none # covered by the layout rules
+resharper_missing_linebreak_highlighting = none # covered by the layout rules
+resharper_bad_empty_braces_line_breaks_highlighting = none # covered by SST1500
 resharper_missing_indent_highlighting = none # covered by editorconfig indent_size
-resharper_missing_blank_lines_highlighting = none # covered by SA1516 / SA1517
+resharper_missing_blank_lines_highlighting = none # covered by SST1516 / SST1517
 resharper_wrong_indent_size_highlighting = none # covered by editorconfig indent_size
 resharper_bad_indent_highlighting = none # covered by editorconfig indent_size
-resharper_bad_expression_braces_line_breaks_highlighting = none # covered by SA layout rules
-resharper_multiple_spaces_highlighting = none # covered by SA1025
-resharper_bad_expression_braces_indent_highlighting = none # covered by SA layout rules
-resharper_bad_control_braces_indent_highlighting = none # covered by SA layout rules
-resharper_bad_preprocessor_indent_highlighting = none # covered by SA layout rules
-resharper_redundant_blank_lines_highlighting = none # covered by SA1516 / SA1507
-resharper_multiple_statements_on_one_line_highlighting = none # covered by SA1119 / SA1503
-resharper_bad_braces_spaces_highlighting = none # covered by SA1012 / SA1013
+resharper_bad_expression_braces_line_breaks_highlighting = none # covered by the layout rules
+resharper_multiple_spaces_highlighting = none # covered by SST1025
+resharper_bad_expression_braces_indent_highlighting = none # covered by the layout rules
+resharper_bad_control_braces_indent_highlighting = none # covered by the layout rules
+resharper_bad_preprocessor_indent_highlighting = none # covered by the layout rules
+resharper_redundant_blank_lines_highlighting = none # covered by SST1516 / SST1507
+resharper_multiple_statements_on_one_line_highlighting = none # covered by SST1119 / SST1503
+resharper_bad_braces_spaces_highlighting = none # covered by SST1012 / SST1013
 resharper_outdent_is_off_prev_level_highlighting = none # editorconfig indentation
-resharper_bad_symbol_spaces_highlighting = none # covered by SA spacing rules
-resharper_bad_colon_spaces_highlighting = none # covered by SA1024
-resharper_bad_semicolon_spaces_highlighting = none # covered by SA1002
-resharper_bad_square_brackets_spaces_highlighting = none # covered by SA1010 / SA1011
-resharper_bad_parens_spaces_highlighting = none # covered by SA1008 / SA1009
+resharper_bad_symbol_spaces_highlighting = none # covered by the spacing rules
+resharper_bad_colon_spaces_highlighting = none # covered by SST1024
+resharper_bad_semicolon_spaces_highlighting = none # covered by SST1002
+resharper_bad_square_brackets_spaces_highlighting = none # covered by SST1010 / SST1011
+resharper_bad_parens_spaces_highlighting = none # covered by SST1008 / SST1009
 
 ###################
-# ReSharper - 'this' qualifier (matches SA1101 = none)
+# ReSharper - 'this' qualifier (SST1117 owns the qualification style)
 ###################
 resharper_redundant_this_qualifier_highlighting = none # we don't follow the this. prefix style
 resharper_arrange_this_qualifier_highlighting = none # we don't follow the this. prefix style
-resharper_arrange_default_access_modifier_highlighting = none # SA1400 requires explicit access modifiers — don't suggest removing them
-resharper_redundant_default_access_modifier_highlighting = none # SA1400 requires explicit access modifiers — don't suggest removing them
-resharper_redundant_access_modifier_highlighting = none # access modifiers are deliberate and SA1400 requires them
-resharper_arrange_type_member_modifiers_highlighting = none # SA1206 handles modifier ordering; don't duplicate
-resharper_redundant_empty_switch_section_highlighting = none # handled by RCS1070
+resharper_arrange_default_access_modifier_highlighting = none # SST1400 requires explicit access modifiers — don't suggest removing them
+resharper_redundant_default_access_modifier_highlighting = none # SST1400 requires explicit access modifiers — don't suggest removing them
+resharper_redundant_access_modifier_highlighting = none # access modifiers are deliberate and SST1400 requires them
+resharper_arrange_type_member_modifiers_highlighting = none # SST1206 handles modifier ordering; don't duplicate
+resharper_redundant_empty_switch_section_highlighting = none # an empty section is how an intentionally ignored case reads
 
 ###################
 # ReSharper - Redundancies / cleanup
@@ -2698,22 +1959,22 @@ resharper_redundant_empty_switch_section_highlighting = none # handled by RCS107
 resharper_redundant_using_directive_highlighting = error # IDE0005 may not fire at compile time reliably — keep Rider nagging
 resharper_redundant_qualifier_highlighting = error # IDE0001 may not fire at compile time reliably — keep Rider nagging
 resharper_redundant_name_qualifier_highlighting = error # IDE0001 may not fire at compile time reliably — keep Rider nagging
-resharper_redundant_base_qualifier_highlighting = none # IDE0009 is disabled (SA1101 = none) — don't nag in Rider either
-resharper_redundant_cast_highlighting = none # handled by RCS1151
-resharper_redundant_explicit_array_creation_highlighting = none # handled by RCS1014
-resharper_redundant_empty_object_creation_argument_list_highlighting = none # handled by RCS1039
+resharper_redundant_base_qualifier_highlighting = none # IDE0009 is disabled (SST1117 owns qualification) — don't nag in Rider either
+resharper_redundant_cast_highlighting = error # a cast that changes nothing is dead weight
+resharper_redundant_explicit_array_creation_highlighting = error # let the element type be inferred
+resharper_redundant_empty_object_creation_argument_list_highlighting = none # an explicit () reads consistently next to argument-carrying calls
 resharper_redundant_lambda_signature_parentheses_highlighting = error # IDE0063 may not fire at compile time reliably — keep Rider nagging
-resharper_redundant_default_member_initializer_highlighting = none # handled by RCS1188
-resharper_redundant_field_initializer_highlighting = none # handled by RCS1129
-resharper_redundant_overriding_member_highlighting = none # handled by RCS1132
-resharper_redundant_verbatim_string_prefix_highlighting = none # handled by RCS1192
-resharper_redundant_string_interpolation_highlighting = none # handled by RCS1105 / RCS1214
-resharper_redundant_to_string_call_highlighting = none # handled by RCS1097
+resharper_redundant_default_member_initializer_highlighting = error # the field already starts at its default
+resharper_redundant_field_initializer_highlighting = error # the field already starts at its default
+resharper_redundant_overriding_member_highlighting = error # an override that only calls base adds nothing
+resharper_redundant_verbatim_string_prefix_highlighting = error # no escape in the literal needs the @
+resharper_redundant_string_interpolation_highlighting = error # the interpolation has no holes
+resharper_redundant_to_string_call_highlighting = error # the value is already a string in this position
 
 ###################
-# ReSharper - Naming (matches SA/CA naming rules)
+# ReSharper - Naming
 ###################
-resharper_inconsistent_naming_highlighting = none # too many false positives on test/fixture naming; SA1300 family covers the real cases
+resharper_inconsistent_naming_highlighting = error # partially handled by SST1300 family but IDE1006 isn't enabled; keep ReSharper active
 
 ###################
 # ReSharper - Unused code (matches CA1801 / CA1823 / IDE0051-0052)
@@ -2731,37 +1992,37 @@ resharper_unused_auto_property_accessor_local_highlighting = none # data-class s
 resharper_unused_auto_property_accessor_global_highlighting = none # public auto-properties may be intentionally exposed
 
 ###################
-# ReSharper - Code quality (matches CA/RCS semantic analyzers)
+# ReSharper - Code quality (matches the CA and PSH semantic analyzers)
 ###################
 resharper_class_never_instantiated_local_highlighting = none # handled by CA1812
 resharper_class_never_instantiated_global_highlighting = suggestion # public types may be instantiated externally
 resharper_class_cannot_be_instantiated_highlighting = none # handled by CA1052
 resharper_class_can_be_sealed_local_highlighting = none # handled by CA1852 (private/internal surface)
 resharper_class_can_be_sealed_global_highlighting = none # public types stay open for inheritance
-resharper_use_nameof_expression_highlighting = none # handled by CA1507 / RCS1015
+resharper_use_nameof_expression_highlighting = none # covered by CA1507
 resharper_possible_null_reference_exception_highlighting = none # handled bynullability analyzer
 resharper_possible_invalid_operation_exception_highlighting = none # handled bynullability analyzer
 resharper_possible_multiple_enumeration_highlighting = none # handled by CA1851
 resharper_possible_mistaken_argument_null_check_highlighting = none # handled by CA1062
-resharper_convert_to_constant_local_highlighting = none # handled by RCS1118
+resharper_convert_to_constant_local_highlighting = none # a local that never changes is fine as a local
 resharper_convert_to_static_class_highlighting = none # handled by CA1052
-resharper_convert_to_auto_property_highlighting = none # handled by RCS1085
-resharper_convert_to_auto_property_when_possible_highlighting = none # handled by RCS1085
-resharper_convert_to_auto_property_with_private_setter_highlighting = none # handled by RCS1085
-resharper_auto_property_can_be_made_get_only_local_highlighting = none # handled by RCS1170
+resharper_convert_to_auto_property_highlighting = none # an explicit backing field is often deliberate
+resharper_convert_to_auto_property_when_possible_highlighting = none # an explicit backing field is often deliberate
+resharper_convert_to_auto_property_with_private_setter_highlighting = none # an explicit backing field is often deliberate
+resharper_auto_property_can_be_made_get_only_local_highlighting = none # a settable property is often part of the intended contract
 resharper_auto_property_can_be_made_get_only_global_highlighting = suggestion # public setters kept for API consumers
 resharper_member_can_be_made_static_local_highlighting = none # handled by CA1822 (private/internal surface)
 resharper_member_can_be_made_static_global_highlighting = none # public members kept virtual for inheritance
 resharper_member_can_be_private_local_highlighting = none # access modifiers are deliberate — don't suggest tightening
 resharper_method_has_async_overload_highlighting = none # sync call sites are intentional (e.g. test setup, disposal, sample code)
 resharper_member_can_be_private_global_highlighting = none # access modifiers are deliberate — don't suggest tightening
-resharper_field_can_be_made_read_only_local_highlighting = none # handled by RCS1169
-resharper_field_can_be_made_read_only_global_highlighting = none # handled by RCS1169
-resharper_merge_into_pattern_highlighting = none # handled by RCS1220
-resharper_merge_conditional_expression_highlighting = none # handled by RCS1173
-resharper_merge_sequential_checks_highlighting = none # handled by RCS1206
-resharper_simplify_conditional_ternary_expression_highlighting = none # handled by RCS1049 / RCS1104
-resharper_simplify_linq_expression_highlighting = error # handled by RCS1077
+resharper_field_can_be_made_read_only_local_highlighting = error # a field never reassigned after construction should say so
+resharper_field_can_be_made_read_only_global_highlighting = error # a field never reassigned after construction should say so
+resharper_merge_into_pattern_highlighting = none # the unmerged form is often the clearer read
+resharper_merge_conditional_expression_highlighting = none # the unmerged form is often the clearer read
+resharper_merge_sequential_checks_highlighting = none # the unmerged form is often the clearer read
+resharper_simplify_conditional_ternary_expression_highlighting = none # the unmerged form is often the clearer read
+resharper_simplify_linq_expression_highlighting = error # a query that collapses to one call should be written that way
 resharper_string_compare_to_is_culture_specific_highlighting = none # handled by CA1310
 resharper_string_ends_with_is_culture_specific_highlighting = none # handled by CA1310
 resharper_string_index_of_is_culture_specific_1_highlighting = none # handled by CA1310
@@ -2776,15 +2037,15 @@ resharper_specify_a_culture_in_string_conversion_explicitly_highlighting = none 
 ###################
 # ReSharper - Control flow / nesting
 ###################
-resharper_invert_if_highlighting = suggestion # related to RCS1208 — Rider is more aggressive
+resharper_invert_if_highlighting = suggestion # inverting to an early return usually reads better, but not always
 resharper_tail_recursive_call_highlighting = suggestion
 
 ###################
-# ReSharper - Documentation (covered by StyleCop SA1600 family)
+# ReSharper - Documentation (covered by the SST1600 family)
 ###################
-resharper_missing_xml_doc_highlighting = none # covered by SA1600 family
-resharper_missing_xml_doc_global_highlighting = none # covered by SA1600 family
-resharper_invalid_xml_doc_comment_highlighting = none # handled by SA1612 / SA1613
+resharper_missing_xml_doc_highlighting = none # covered by SST1600 family
+resharper_missing_xml_doc_global_highlighting = none # covered by SST1600 family
+resharper_invalid_xml_doc_comment_highlighting = none # handled by SST1612 / SST1613
 
 ###################
 # ReSharper - Typo / spelling (not enforced)
@@ -2815,7 +2076,7 @@ indent_size = 2
 [*.builds]
 indent_size = 2
 
-[*.{xml,stylecop,resx,ruleset}]
+[*.{xml,resx,ruleset}]
 indent_size = 2
 
 [*.{props,targets,config,nuspec}]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,6 @@
             ],
             "groupName": "analyzers",
             "matchPackageNames": [
-                "/^Roslynator\\./",
                 "/Sharp\\.Analyzers$/"
             ]
         },
@@ -24,17 +23,6 @@
             "matchPackageNames": [
                 "/^MinVer$/",
                 "/^Microsoft\\.SourceLink\\./"
-            ]
-        },
-        {
-            "description": "Verify.TUnit is built against a specific TUnit version. The shared preset groups TUnit separately from Verify.*, which can split a matched pair across two PRs and red the build; keep them together here.",
-            "matchManagers": [
-                "nuget"
-            ],
-            "groupName": "TUnit",
-            "matchPackageNames": [
-                "/^TUnit(\\.|$)/",
-                "/^Verify\\./"
             ]
         }
     ]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,25 @@
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '41 8 * * 3'
+
+permissions:
+  security-events: write
+  contents: read
+  packages: read
+  actions: read
+
+jobs:
+  codeql:
+    uses: reactiveui/actions-common/.github/workflows/workflow-common-codeql.yml@main
+    with:
+      srcFolder: src
+      solutionFile: ReactiveUI.Avalonia.slnx
+      analyzeCSharp: true
+      analyzeActions: true
+      analyzeJavaScript: false

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,28 @@
+name: SonarCloud
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  sonarcloud:
+    uses: reactiveui/actions-common/.github/workflows/workflow-common-sonarcloud.yml@main
+    with:
+      solutionFile: ReactiveUI.Avalonia.slnx
+      minverMinimumMajorMinor: '12.1'
+      sonarProjectKey: reactiveui_ReactiveUI.Avalonia
+      sonarOrganization: reactiveui
+      sonarExclusions: '**/tests/**,**/examples/**,**/TestResults/**'
+      sonarCoverageExclusions: '**/tests/**,**/examples/**,**/*Tests/**,**/*Tests.cs'
+      # Each container package implements the same registration shape against a different container,
+      # so the repetition across the AvaloniaMixins files is the integration, not a copy to share.
+      sonarCpdExclusions: '**/tests/**,**/examples/**,**/AvaloniaMixins.cs'
+      sonarTestExclusions: '**/tests/**,**/examples/**'
+      testTimeout: '15m'
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ dotnet restore ReactiveUI.Avalonia.slnx
 # Build the solution
 dotnet build ReactiveUI.Avalonia.slnx -c Release
 
-# Build with warnings as errors (includes StyleCop violations)
+# Build with warnings as errors (includes analyzer violations)
 dotnet build ReactiveUI.Avalonia.slnx -c Release -warnaserror
 
 # Clean the solution
@@ -145,11 +145,39 @@ cat /tmp/coverage-report/Summary.txt
 reportgenerator -reports:"tests/ReactiveUI.Avalonia.Tests/bin/Release/net10.0/TestResults/*.cobertura.xml" -targetdir:/tmp/coverage-report -reporttypes:Html
 ```
 
+### Public API Baselines
+
+Every shipping project checks in its public surface as `PublicAPI/{TargetFramework}/PublicAPI.txt`, one baseline per target framework, enforced by `PublicApiSharp.Analyzers`. The baseline is ordinary C# that reads like source, so a reviewer can tell from the diff alone whether an API change is additive.
+
+The build fails when the surface and the baseline disagree:
+
+- `PAS0001` - a public member is missing from the baseline (reported on the declaration)
+- `PAS0002` - a baseline entry no longer exists in source (reported on the baseline line)
+- `PAS0003` - a member's signature differs from the baseline (reported on the declaration)
+
+There is no shipped/unshipped split. An intentional API change is accepted by regenerating the baseline in the same commit that makes the change.
+
+```powershell
+# Regenerate a project's baseline. dotnet format writes ONE baseline per run
+# (it fixes a single inner build at a time), so on a multi-targeting project
+# repeat the command until the build is clean - once per target framework.
+dotnet format analyzers ReactiveUI.Avalonia/ReactiveUI.Avalonia.csproj --diagnostics PAS0001 PAS0003 --severity info
+
+# Adding a new target framework? Create the empty baseline first - the analyzer
+# stays silent until the file exists, so a missing one tracks nothing at all.
+mkdir -p ReactiveUI.Avalonia/PublicAPI/net12.0 && touch ReactiveUI.Avalonia/PublicAPI/net12.0/PublicAPI.txt
+```
+
+**Note:** `PAS0004` (no baseline for this target framework) is reported at `CSC` with no source location, so Roslyn only honours its severity from a *global* analyzer config. The `.editorconfig` entry under `[*.cs]` has no effect, which is why the empty-file step above is manual.
+
+Test projects are excluded via `TrackPublicApi` in `src/Directory.Build.props`.
+
 ### Key Configuration Files
 
 - `global.json` - Specifies `"Microsoft.Testing.Platform"` as the test runner
 - `testconfig.json` - Configures test execution (`"parallel": false`) and code coverage (Cobertura format)
-- `Directory.Build.props` - Enables `TestingPlatformDotnetTestSupport` for test projects
+- `Directory.Build.props` - Enables `TestingPlatformDotnetTestSupport` for test projects, and sets `TrackPublicApi` for public API baselines
+- `Directory.Packages.props` - Central package versions; `RoslynCommonAnalyzersVersion` pins StyleSharp, PerformanceSharp and SecuritySharp to a single shared version
 
 ## Architecture Overview
 
@@ -185,8 +213,7 @@ ReactiveUI.Avalonia provides platform-specific extensions that integrate Reactiv
 ### Style Enforcement
 
 - EditorConfig rules (`.editorconfig`) - comprehensive C# formatting and naming conventions
-- StyleCop Analyzers - builds fail on violations
-- Roslynator Analyzers - additional code quality rules
+- StyleSharp (SST), PerformanceSharp (PSH) and SecuritySharp (SES) analyzers - builds fail on violations
 - **All elements require XML documentation comments** (public, internal, and private)
 - **No `#pragma` directives** — use `[SuppressMessage]` attributes when suppression is truly needed
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -74,7 +74,6 @@
     <PackageReference Include="TUnit" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
-    <PackageReference Include="Verify.TUnit" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
@@ -92,6 +91,17 @@
     <PackageReference Include="StyleSharp.Analyzers" PrivateAssets="all"/>
     <PackageReference Include="PerformanceSharp.Analyzers" PrivateAssets="all"/>
     <PackageReference Include="SecuritySharp.Analyzers" PrivateAssets="all"/>
-    <PackageReference Include="Roslynator.Analyzers" PrivateAssets="All" />
+  </ItemGroup>
+
+  <!-- Baselines live in <Project>/PublicAPI/<tfm>/PublicAPI.txt; the analyzer resolves the per-TFM
+       path itself per inner build, so multi-targeting needs no AdditionalFiles wiring here. -->
+  <PropertyGroup>
+    <TrackPublicApi Condition="'$(TrackPublicApi)' == ''">true</TrackPublicApi>
+    <TrackPublicApi Condition="'$(IsTestProject)' == 'true'">false</TrackPublicApi>
+    <TrackPublicApi Condition="$(MSBuildProjectDirectory.Contains('examples'))">false</TrackPublicApi>
+    <EnablePublicApiBaseline>$(TrackPublicApi)</EnablePublicApiBaseline>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(TrackPublicApi)' == 'true'">
+    <PackageReference Include="PublicApiSharp.Analyzers" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,7 +6,7 @@
     <SplatVersion>21.0.0</SplatVersion>
     <!-- StyleSharp.Analyzers, PerformanceSharp.Analyzers and SecuritySharp.Analyzers ship from the
          same release pipeline and always share a version. -->
-    <RoslynCommonAnalyzersVersion>3.46.1</RoslynCommonAnalyzersVersion>
+    <RoslynCommonAnalyzersVersion>4.1.3</RoslynCommonAnalyzersVersion>
     <ReactiveUIPrimitivesVersion>7.4.0</ReactiveUIPrimitivesVersion>
   </PropertyGroup>
 
@@ -16,7 +16,7 @@
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Headless" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" />
     <PackageVersion Include="MinVer" Version="8.0.0" />
     <PackageVersion Include="ReactiveUI" Version="24.2.0" />
     <PackageVersion Include="ReactiveUI.Primitives" Version="$(ReactiveUIPrimitivesVersion)" />
@@ -33,16 +33,15 @@
     <PackageVersion Include="StyleSharp.Analyzers" Version="$(RoslynCommonAnalyzersVersion)" />
     <PackageVersion Include="PerformanceSharp.Analyzers" Version="$(RoslynCommonAnalyzersVersion)" />
     <PackageVersion Include="SecuritySharp.Analyzers" Version="$(RoslynCommonAnalyzersVersion)" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="5.0.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="10.0.11" />
+    <PackageVersion Include="PublicApiSharp.Analyzers" Version="1.0.8" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.12" />
     <PackageVersion Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageVersion Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Label="Test packages">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0" />
-    <PackageVersion Include="TUnit" Version="1.66.27" />
-    <PackageVersion Include="Verify.TUnit" Version="32.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.2" />
+    <PackageVersion Include="TUnit" Version="1.67.0" />
   </ItemGroup>
 </Project>

--- a/src/ReactiveUI.Avalonia.Autofac.Reactive/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Autofac.Reactive/PublicAPI/net10.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver>? withResolver, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Autofac.Reactive/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Autofac.Reactive/PublicAPI/net11.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver>? withResolver, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Autofac.Reactive/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Autofac.Reactive/PublicAPI/net8.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver>? withResolver, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Autofac.Reactive/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Autofac.Reactive/PublicAPI/net9.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver>? withResolver, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Autofac.Reactive/ReactiveUI.Avalonia.Autofac.Reactive.csproj
+++ b/src/ReactiveUI.Avalonia.Autofac.Reactive/ReactiveUI.Avalonia.Autofac.Reactive.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\ReactiveUI.Avalonia.Autofac\*.cs" Exclude="..\ReactiveUI.Avalonia.Autofac\bin\**;..\ReactiveUI.Avalonia.Autofac\obj\**" Link="%(Filename)%(Extension)" />
+    <Compile Include="..\Shared\SplatApp.cs" Link="Shared\SplatApp.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Splat.Autofac" />

--- a/src/ReactiveUI.Avalonia.Autofac/AvaloniaMixins.cs
+++ b/src/ReactiveUI.Avalonia.Autofac/AvaloniaMixins.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
+
 #if REACTIVE_SHIM
 namespace ReactiveUI.Avalonia.Reactive.Splat;
 #else
@@ -14,30 +16,19 @@ namespace ReactiveUI.Avalonia.Splat;
 /// </remarks>
 public static class AvaloniaMixins
 {
-    /// <summary>Builds the ReactiveUI Splat application when it has not already been built.</summary>
-    /// <param name="rxuiBuilder">The ReactiveUI builder.</param>
-    private static void BuildAppIfNeeded(IReactiveUIBuilder rxuiBuilder)
-    {
-        if (SplatBuilder.HasBeenBuilt)
-        {
-            return;
-        }
-
-        _ = rxuiBuilder.BuildApp();
-    }
-
     /// <summary>Extends Avalonia application builders with Autofac ReactiveUI registration.</summary>
     /// <param name="builder">The Avalonia application builder to extend.</param>
     extension(AppBuilder builder)
     {
         /// <summary>Configures the application to use ReactiveUI with Autofac as the dependency injection container.</summary>
+        /// <param name="containerConfig">Configures the Autofac container.</param>
+        /// <returns>The application builder instance, enabling further configuration or chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the builder or <paramref name="containerConfig"/> is null.</exception>
         /// <remarks>
         /// This method registers the Autofac resolver and allows the container, resolver, and ReactiveUI builder to be
         /// configured.
         /// </remarks>
-        /// <param name="containerConfig">Configures the Autofac container.</param>
-        /// <returns>The application builder instance, enabling further configuration or chaining.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if the builder or <paramref name="containerConfig"/> is null.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public AppBuilder UseReactiveUIWithAutofac(Action<ContainerBuilder> containerConfig) =>
             builder.UseReactiveUIWithAutofac(containerConfig, null, null);
 
@@ -45,6 +36,7 @@ public static class AvaloniaMixins
         /// <param name="containerConfig">Configures the Autofac container.</param>
         /// <param name="withResolver">Customizes the Autofac resolver.</param>
         /// <returns>The application builder instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public AppBuilder UseReactiveUIWithAutofac(
             Action<ContainerBuilder> containerConfig,
             Action<AutofacDependencyResolver> withResolver) =>
@@ -73,7 +65,7 @@ public static class AvaloniaMixins
                 var rxuiBuilder = AppLocator.CurrentMutable.CreateReactiveUIBuilder();
                 _ = rxuiBuilder.WithAvalonia();
                 withReactiveUIBuilder?.Invoke(rxuiBuilder);
-                BuildAppIfNeeded(rxuiBuilder);
+                SplatApp.BuildIfNeeded(rxuiBuilder);
 
                 var container = containerBuilder.Build();
                 var autofacResolver = container.Resolve<AutofacDependencyResolver>();

--- a/src/ReactiveUI.Avalonia.Autofac/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Autofac/PublicAPI/net10.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver>? withResolver, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Autofac/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Autofac/PublicAPI/net11.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver>? withResolver, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Autofac/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Autofac/PublicAPI/net8.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver>? withResolver, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Autofac/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Autofac/PublicAPI/net9.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithAutofac(System.Action<Autofac.ContainerBuilder> containerConfig, System.Action<Splat.Autofac.AutofacDependencyResolver>? withResolver, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Autofac/ReactiveUI.Avalonia.Autofac.csproj
+++ b/src/ReactiveUI.Avalonia.Autofac/ReactiveUI.Avalonia.Autofac.csproj
@@ -6,7 +6,10 @@
     <PackageTags>mvvm;reactiveui;rx;reactive extensions;observable;LINQ;events;frp;avalonia;net;netcore</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Splat.Autofac" />  
+    <Compile Include="..\Shared\SplatApp.cs" Link="Shared\SplatApp.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Splat.Autofac" />
     <ProjectReference Include="..\ReactiveUI.Avalonia\ReactiveUI.Avalonia.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ReactiveUI.Avalonia.DryIoc.Reactive/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.DryIoc.Reactive/PublicAPI/net10.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.DryIoc.Reactive/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.DryIoc.Reactive/PublicAPI/net11.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.DryIoc.Reactive/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.DryIoc.Reactive/PublicAPI/net8.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.DryIoc.Reactive/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.DryIoc.Reactive/PublicAPI/net9.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.DryIoc.Reactive/ReactiveUI.Avalonia.DryIoc.Reactive.csproj
+++ b/src/ReactiveUI.Avalonia.DryIoc.Reactive/ReactiveUI.Avalonia.DryIoc.Reactive.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\ReactiveUI.Avalonia.DryIoc\*.cs" Exclude="..\ReactiveUI.Avalonia.DryIoc\bin\**;..\ReactiveUI.Avalonia.DryIoc\obj\**" Link="%(Filename)%(Extension)" />
+    <Compile Include="..\Shared\SplatApp.cs" Link="Shared\SplatApp.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Splat.DryIoc" />

--- a/src/ReactiveUI.Avalonia.DryIoc/AvaloniaMixins.cs
+++ b/src/ReactiveUI.Avalonia.DryIoc/AvaloniaMixins.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
+
 #if REACTIVE_SHIM
 namespace ReactiveUI.Avalonia.Reactive.Splat;
 #else
@@ -10,29 +12,18 @@ namespace ReactiveUI.Avalonia.Splat;
 /// <summary>Provides extension methods for configuring Avalonia applications to use ReactiveUI with DryIoc.</summary>
 public static class AvaloniaMixins
 {
-    /// <summary>Builds the ReactiveUI Splat application when it has not already been built.</summary>
-    /// <param name="rxuiBuilder">The ReactiveUI builder.</param>
-    private static void BuildAppIfNeeded(IReactiveUIBuilder rxuiBuilder)
-    {
-        if (SplatBuilder.HasBeenBuilt)
-        {
-            return;
-        }
-
-        _ = rxuiBuilder.BuildApp();
-    }
-
     /// <summary>Extends Avalonia application builders with DryIoc ReactiveUI registration.</summary>
     /// <param name="builder">The Avalonia application builder to extend.</param>
     extension(AppBuilder builder)
     {
         /// <summary>Configures the application to use ReactiveUI with DryIoc as the dependency injection container.</summary>
-        /// <remarks>
-        /// The container configuration delegate registers application services before the ReactiveUI builder is built.
-        /// </remarks>
         /// <param name="containerConfig">Configures the DryIoc container.</param>
         /// <returns>The application builder instance, configured to use ReactiveUI with DryIoc.</returns>
         /// <exception cref="ArgumentNullException">Thrown if the builder or <paramref name="containerConfig"/> is null.</exception>
+        /// <remarks>
+        /// The container configuration delegate registers application services before the ReactiveUI builder is built.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public AppBuilder UseReactiveUIWithDryIoc(Action<Container> containerConfig) =>
             builder.UseReactiveUIWithDryIoc(containerConfig, null);
 
@@ -40,6 +31,7 @@ public static class AvaloniaMixins
         /// <param name="containerConfig">Configures the DryIoc container.</param>
         /// <param name="withReactiveUIBuilder">Customizes the ReactiveUI builder, or null.</param>
         /// <returns>The application builder instance.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the builder or <paramref name="containerConfig"/> is null.</exception>
         public AppBuilder UseReactiveUIWithDryIoc(
             Action<Container> containerConfig,
             Action<ReactiveUIBuilder>? withReactiveUIBuilder) =>
@@ -59,7 +51,7 @@ public static class AvaloniaMixins
                     var rxuiBuilder = AppLocator.CurrentMutable.CreateReactiveUIBuilder();
                     _ = rxuiBuilder.WithAvalonia();
                     withReactiveUIBuilder?.Invoke(rxuiBuilder);
-                    BuildAppIfNeeded(rxuiBuilder);
+                    SplatApp.BuildIfNeeded(rxuiBuilder);
                 })
             };
     }

--- a/src/ReactiveUI.Avalonia.DryIoc/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.DryIoc/PublicAPI/net10.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.DryIoc/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.DryIoc/PublicAPI/net11.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.DryIoc/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.DryIoc/PublicAPI/net8.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.DryIoc/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.DryIoc/PublicAPI/net9.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDryIoc(System.Action<DryIoc.Container> containerConfig, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.DryIoc/ReactiveUI.Avalonia.DryIoc.csproj
+++ b/src/ReactiveUI.Avalonia.DryIoc/ReactiveUI.Avalonia.DryIoc.csproj
@@ -6,6 +6,9 @@
     <PackageTags>mvvm;reactiveui;rx;reactive extensions;observable;LINQ;events;frp;avalonia;net;netcore</PackageTags>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\Shared\SplatApp.cs" Link="Shared\SplatApp.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Splat.DryIoc" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive/PublicAPI/net10.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?>? withResolver, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive/PublicAPI/net11.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?>? withResolver, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive/PublicAPI/net8.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?>? withResolver, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive/PublicAPI/net9.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?>? withResolver, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive.csproj
+++ b/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection\*.cs" Exclude="..\ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection\bin\**;..\ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection\obj\**" Link="%(Filename)%(Extension)" />
+    <Compile Include="..\Shared\SplatApp.cs" Link="Shared\SplatApp.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" />

--- a/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/AvaloniaMixins.cs
+++ b/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/AvaloniaMixins.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
+
 #if REACTIVE_SHIM
 namespace ReactiveUI.Avalonia.Reactive.Splat;
 #else
@@ -13,29 +15,18 @@ namespace ReactiveUI.Avalonia.Splat;
 /// </remarks>
 public static class AvaloniaMixins
 {
-    /// <summary>Builds the ReactiveUI Splat application when it has not already been built.</summary>
-    /// <param name="rxuiBuilder">The ReactiveUI builder.</param>
-    private static void BuildAppIfNeeded(IReactiveUIBuilder rxuiBuilder)
-    {
-        if (SplatBuilder.HasBeenBuilt)
-        {
-            return;
-        }
-
-        _ = rxuiBuilder.BuildApp();
-    }
-
     /// <summary>Extends Avalonia application builders with Microsoft dependency injection registration.</summary>
     /// <param name="builder">The Avalonia application builder to extend.</param>
     extension(AppBuilder builder)
     {
         /// <summary>Configures the application to use ReactiveUI with Microsoft dependency injection.</summary>
-        /// <remarks>
-        /// Services are registered in an IServiceCollection before the method builds the IServiceProvider.
-        /// </remarks>
         /// <param name="containerConfig">Configures the IServiceCollection.</param>
         /// <returns>The application builder instance, configured to use ReactiveUI with Microsoft dependency injection.</returns>
         /// <exception cref="ArgumentNullException">Thrown if builder or containerConfig is null.</exception>
+        /// <remarks>
+        /// Services are registered in an IServiceCollection before the method builds the IServiceProvider.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(
             Action<IServiceCollection> containerConfig) =>
             builder.UseReactiveUIWithMicrosoftDependencyResolver(containerConfig, null, null);
@@ -44,6 +35,7 @@ public static class AvaloniaMixins
         /// <param name="containerConfig">Configures the IServiceCollection.</param>
         /// <param name="withResolver">Customizes the built service provider.</param>
         /// <returns>The application builder instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(
             Action<IServiceCollection> containerConfig,
             Action<IServiceProvider?> withResolver) =>
@@ -54,6 +46,7 @@ public static class AvaloniaMixins
         /// <param name="withResolver">Customizes the service provider, or null.</param>
         /// <param name="withReactiveUIBuilder">Customizes the ReactiveUI builder, or null.</param>
         /// <returns>The application builder instance.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the builder or <paramref name="containerConfig"/> is null.</exception>
         public AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(
             Action<IServiceCollection> containerConfig,
             Action<IServiceProvider?>? withResolver,
@@ -74,7 +67,7 @@ public static class AvaloniaMixins
                     var rxuiBuilder = AppLocator.CurrentMutable.CreateReactiveUIBuilder();
                     _ = rxuiBuilder.WithAvalonia();
                     withReactiveUIBuilder?.Invoke(rxuiBuilder);
-                    BuildAppIfNeeded(rxuiBuilder);
+                    SplatApp.BuildIfNeeded(rxuiBuilder);
 
                     var serviceProvider = serviceCollection.BuildServiceProvider();
                     serviceProvider.UseMicrosoftDependencyResolver();

--- a/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/PublicAPI/net10.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?>? withResolver, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/PublicAPI/net11.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?>? withResolver, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/PublicAPI/net8.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?>? withResolver, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/PublicAPI/net9.0/PublicAPI.txt
@@ -1,0 +1,13 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?> withResolver) { }
+        public Avalonia.AppBuilder UseReactiveUIWithMicrosoftDependencyResolver(System.Action<Microsoft.Extensions.DependencyInjection.IServiceCollection> containerConfig, System.Action<System.IServiceProvider?>? withResolver, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.csproj
+++ b/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.csproj
@@ -6,6 +6,9 @@
     <PackageTags>mvvm;reactiveui;rx;reactive extensions;observable;LINQ;events;frp;avalonia;net;netcore</PackageTags>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\Shared\SplatApp.cs" Link="Shared\SplatApp.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" />
     <ProjectReference Include="..\ReactiveUI.Avalonia\ReactiveUI.Avalonia.csproj" />
   </ItemGroup>

--- a/src/ReactiveUI.Avalonia.Ninject.Reactive/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Ninject.Reactive/PublicAPI/net10.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Ninject.Reactive/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Ninject.Reactive/PublicAPI/net11.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Ninject.Reactive/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Ninject.Reactive/PublicAPI/net8.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Ninject.Reactive/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Ninject.Reactive/PublicAPI/net9.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Ninject.Reactive/ReactiveUI.Avalonia.Ninject.Reactive.csproj
+++ b/src/ReactiveUI.Avalonia.Ninject.Reactive/ReactiveUI.Avalonia.Ninject.Reactive.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\ReactiveUI.Avalonia.Ninject\*.cs" Exclude="..\ReactiveUI.Avalonia.Ninject\bin\**;..\ReactiveUI.Avalonia.Ninject\obj\**" Link="%(Filename)%(Extension)" />
+    <Compile Include="..\Shared\SplatApp.cs" Link="Shared\SplatApp.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Splat.Ninject" />

--- a/src/ReactiveUI.Avalonia.Ninject/AvaloniaMixins.cs
+++ b/src/ReactiveUI.Avalonia.Ninject/AvaloniaMixins.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
+
 #if REACTIVE_SHIM
 namespace ReactiveUI.Avalonia.Reactive.Splat;
 #else
@@ -11,29 +13,18 @@ namespace ReactiveUI.Avalonia.Splat;
 /// <remarks>This static class contains mixin methods that enable the configuration of dependency injection using Ninject alongside ReactiveUI in Avalonia app builders.</remarks>
 public static class AvaloniaMixins
 {
-    /// <summary>Builds the ReactiveUI Splat application when it has not already been built.</summary>
-    /// <param name="rxuiBuilder">The ReactiveUI builder.</param>
-    private static void BuildAppIfNeeded(IReactiveUIBuilder rxuiBuilder)
-    {
-        if (SplatBuilder.HasBeenBuilt)
-        {
-            return;
-        }
-
-        _ = rxuiBuilder.BuildApp();
-    }
-
     /// <summary>Extends Avalonia application builders with Ninject ReactiveUI registration.</summary>
     /// <param name="builder">The Avalonia application builder to extend.</param>
     extension(AppBuilder builder)
     {
         /// <summary>Configures the application to use ReactiveUI with a Ninject dependency injection container.</summary>
-        /// <remarks>
-        /// The Ninject container is registered with the service locator before the ReactiveUI builder is built.
-        /// </remarks>
         /// <param name="containerConfig">Configures the Ninject container.</param>
         /// <returns>The application builder instance with ReactiveUI and Ninject configured.</returns>
         /// <exception cref="ArgumentNullException">Thrown if the builder or <paramref name="containerConfig"/> is null.</exception>
+        /// <remarks>
+        /// The Ninject container is registered with the service locator before the ReactiveUI builder is built.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public AppBuilder UseReactiveUIWithNinject(Action<StandardKernel> containerConfig) =>
             builder.UseReactiveUIWithNinject(containerConfig, null);
 
@@ -41,6 +32,7 @@ public static class AvaloniaMixins
         /// <param name="containerConfig">Configures the Ninject container.</param>
         /// <param name="withReactiveUIBuilder">Customizes the ReactiveUI builder, or null.</param>
         /// <returns>The application builder instance.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the builder or <paramref name="containerConfig"/> is null.</exception>
         public AppBuilder UseReactiveUIWithNinject(
             Action<StandardKernel> containerConfig,
             Action<ReactiveUIBuilder>? withReactiveUIBuilder) =>
@@ -60,7 +52,7 @@ public static class AvaloniaMixins
                     var rxuiBuilder = AppLocator.CurrentMutable.CreateReactiveUIBuilder();
                     _ = rxuiBuilder.WithAvalonia();
                     withReactiveUIBuilder?.Invoke(rxuiBuilder);
-                    BuildAppIfNeeded(rxuiBuilder);
+                    SplatApp.BuildIfNeeded(rxuiBuilder);
                 })
             };
     }

--- a/src/ReactiveUI.Avalonia.Ninject/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Ninject/PublicAPI/net10.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Ninject/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Ninject/PublicAPI/net11.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Ninject/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Ninject/PublicAPI/net8.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Ninject/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Ninject/PublicAPI/net9.0/PublicAPI.txt
@@ -1,0 +1,11 @@
+namespace ReactiveUI.Avalonia.Splat;
+
+public static class AvaloniaMixins
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig) { }
+        public Avalonia.AppBuilder UseReactiveUIWithNinject(System.Action<Ninject.StandardKernel> containerConfig, System.Action<ReactiveUI.Builder.ReactiveUIBuilder>? withReactiveUIBuilder) { }
+    }
+}

--- a/src/ReactiveUI.Avalonia.Ninject/ReactiveUI.Avalonia.Ninject.csproj
+++ b/src/ReactiveUI.Avalonia.Ninject/ReactiveUI.Avalonia.Ninject.csproj
@@ -6,6 +6,9 @@
     <PackageTags>mvvm;reactiveui;rx;reactive extensions;observable;LINQ;events;frp;avalonia;net;netcore</PackageTags>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\Shared\SplatApp.cs" Link="Shared\SplatApp.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Splat.Ninject" />
     <ProjectReference Include="..\ReactiveUI.Avalonia\ReactiveUI.Avalonia.csproj" />
   </ItemGroup>

--- a/src/ReactiveUI.Avalonia.Reactive/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Reactive/PublicAPI/net10.0/PublicAPI.txt
@@ -1,0 +1,142 @@
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia")]
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Tests")]
+namespace ReactiveUI.Avalonia.Reactive;
+
+public static class AppBuilderExtensions
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        public Avalonia.AppBuilder RegisterReactiveUIViews(params System.Reflection.Assembly[] assemblies) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromAssemblyOf<TMarker>(params TMarker[] markers) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromEntryAssembly() { }
+        public Avalonia.AppBuilder UseReactiveUI(System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder> withReactiveUIBuilder) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDIContainer<TContainer>(System.Func<TContainer> containerFactory, System.Action<TContainer> containerConfig, System.Func<TContainer, Splat.IDependencyResolver> dependencyResolverFactory, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder> configureReactiveUI) where TContainer : class { }
+    }
+    extension(ReactiveUI.Reactive.Builder.IReactiveUIBuilder builder)
+    {
+        public ReactiveUI.Reactive.Builder.IReactiveUIBuilder WithAvalonia() { }
+    }
+}
+public class AutoDataTemplateBindingHook : ReactiveUI.IPropertyBindingHook
+{
+    public AutoDataTemplateBindingHook() { }
+    public bool ExecuteHook(object? source, object target, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction) { }
+}
+[System.Diagnostics.DebuggerDisplay("AutoSuspendHelper: {_shouldPersistState}")]
+public sealed class AutoSuspendHelper : Splat.IEnableLogger, System.IDisposable
+{
+    public AutoSuspendHelper(Avalonia.Controls.ApplicationLifetimes.IApplicationLifetime lifetime) { }
+    public void Dispose() { }
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    public void OnFrameworkInitializationCompleted() { }
+}
+public class AvaloniaActivationForViewFetcher : ReactiveUI.IActivationForViewFetcher
+{
+    public AvaloniaActivationForViewFetcher() { }
+    public System.IObservable<bool> GetActivationForView(ReactiveUI.IActivatableView view) { }
+    public int GetAffinityForView(System.Type view) { }
+}
+public static class AvaloniaObjectReactiveExtensions
+{
+    extension(Avalonia.AvaloniaObject o)
+    {
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property) { }
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+        public System.Reactive.Subjects.ISubject<object?> GetSubject(Avalonia.AvaloniaProperty property) { }
+        public System.Reactive.Subjects.ISubject<object?> GetSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public System.Reactive.Subjects.ISubject<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public System.Reactive.Subjects.ISubject<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+    }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControl: {ViewModel}")]
+public class ReactiveUserControl<TViewModel> : ReactiveUI.Avalonia.Reactive.ReactiveUserControlBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveUserControl() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControlBase: {ToString(),nq}")]
+public class ReactiveUserControlBase : Avalonia.Controls.UserControl, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveUserControlBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindow: {ViewModel}")]
+public class ReactiveWindow<TViewModel> : ReactiveUI.Avalonia.Reactive.ReactiveWindowBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveWindow() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindowBase: {ToString(),nq}")]
+public class ReactiveWindowBase : Avalonia.Controls.Window, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveWindowBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("RoutedViewHost: {Router}")]
+public class RoutedViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IActivatableView, Splat.IEnableLogger
+{
+    public RoutedViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<ReactiveUI.Reactive.RoutingState?> RouterProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public object? DefaultContent { get; set; }
+    public ReactiveUI.Reactive.RoutingState? Router { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}
+[System.Diagnostics.DebuggerDisplay("ViewModelViewHost: {ViewModel}")]
+public class ViewModelViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IViewFor, Splat.IEnableLogger
+{
+    public ViewModelViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public static readonly Avalonia.AvaloniaProperty<object?> ViewModelProperty;
+    public object? DefaultContent { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    public object? ViewModel { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}

--- a/src/ReactiveUI.Avalonia.Reactive/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Reactive/PublicAPI/net11.0/PublicAPI.txt
@@ -1,0 +1,142 @@
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia")]
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Tests")]
+namespace ReactiveUI.Avalonia.Reactive;
+
+public static class AppBuilderExtensions
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        public Avalonia.AppBuilder RegisterReactiveUIViews(params System.Reflection.Assembly[] assemblies) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromAssemblyOf<TMarker>(params TMarker[] markers) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromEntryAssembly() { }
+        public Avalonia.AppBuilder UseReactiveUI(System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder> withReactiveUIBuilder) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDIContainer<TContainer>(System.Func<TContainer> containerFactory, System.Action<TContainer> containerConfig, System.Func<TContainer, Splat.IDependencyResolver> dependencyResolverFactory, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder> configureReactiveUI) where TContainer : class { }
+    }
+    extension(ReactiveUI.Reactive.Builder.IReactiveUIBuilder builder)
+    {
+        public ReactiveUI.Reactive.Builder.IReactiveUIBuilder WithAvalonia() { }
+    }
+}
+public class AutoDataTemplateBindingHook : ReactiveUI.IPropertyBindingHook
+{
+    public AutoDataTemplateBindingHook() { }
+    public bool ExecuteHook(object? source, object target, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction) { }
+}
+[System.Diagnostics.DebuggerDisplay("AutoSuspendHelper: {_shouldPersistState}")]
+public sealed class AutoSuspendHelper : Splat.IEnableLogger, System.IDisposable
+{
+    public AutoSuspendHelper(Avalonia.Controls.ApplicationLifetimes.IApplicationLifetime lifetime) { }
+    public void Dispose() { }
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    public void OnFrameworkInitializationCompleted() { }
+}
+public class AvaloniaActivationForViewFetcher : ReactiveUI.IActivationForViewFetcher
+{
+    public AvaloniaActivationForViewFetcher() { }
+    public System.IObservable<bool> GetActivationForView(ReactiveUI.IActivatableView view) { }
+    public int GetAffinityForView(System.Type view) { }
+}
+public static class AvaloniaObjectReactiveExtensions
+{
+    extension(Avalonia.AvaloniaObject o)
+    {
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property) { }
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+        public System.Reactive.Subjects.ISubject<object?> GetSubject(Avalonia.AvaloniaProperty property) { }
+        public System.Reactive.Subjects.ISubject<object?> GetSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public System.Reactive.Subjects.ISubject<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public System.Reactive.Subjects.ISubject<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+    }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControl: {ViewModel}")]
+public class ReactiveUserControl<TViewModel> : ReactiveUI.Avalonia.Reactive.ReactiveUserControlBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveUserControl() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControlBase: {ToString(),nq}")]
+public class ReactiveUserControlBase : Avalonia.Controls.UserControl, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveUserControlBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindow: {ViewModel}")]
+public class ReactiveWindow<TViewModel> : ReactiveUI.Avalonia.Reactive.ReactiveWindowBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveWindow() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindowBase: {ToString(),nq}")]
+public class ReactiveWindowBase : Avalonia.Controls.Window, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveWindowBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("RoutedViewHost: {Router}")]
+public class RoutedViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IActivatableView, Splat.IEnableLogger
+{
+    public RoutedViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<ReactiveUI.Reactive.RoutingState?> RouterProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public object? DefaultContent { get; set; }
+    public ReactiveUI.Reactive.RoutingState? Router { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}
+[System.Diagnostics.DebuggerDisplay("ViewModelViewHost: {ViewModel}")]
+public class ViewModelViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IViewFor, Splat.IEnableLogger
+{
+    public ViewModelViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public static readonly Avalonia.AvaloniaProperty<object?> ViewModelProperty;
+    public object? DefaultContent { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    public object? ViewModel { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}

--- a/src/ReactiveUI.Avalonia.Reactive/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Reactive/PublicAPI/net8.0/PublicAPI.txt
@@ -1,0 +1,142 @@
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia")]
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Tests")]
+namespace ReactiveUI.Avalonia.Reactive;
+
+public static class AppBuilderExtensions
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        public Avalonia.AppBuilder RegisterReactiveUIViews(params System.Reflection.Assembly[] assemblies) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromAssemblyOf<TMarker>(params TMarker[] markers) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromEntryAssembly() { }
+        public Avalonia.AppBuilder UseReactiveUI(System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder> withReactiveUIBuilder) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDIContainer<TContainer>(System.Func<TContainer> containerFactory, System.Action<TContainer> containerConfig, System.Func<TContainer, Splat.IDependencyResolver> dependencyResolverFactory, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder> configureReactiveUI) where TContainer : class { }
+    }
+    extension(ReactiveUI.Reactive.Builder.IReactiveUIBuilder builder)
+    {
+        public ReactiveUI.Reactive.Builder.IReactiveUIBuilder WithAvalonia() { }
+    }
+}
+public class AutoDataTemplateBindingHook : ReactiveUI.IPropertyBindingHook
+{
+    public AutoDataTemplateBindingHook() { }
+    public bool ExecuteHook(object? source, object target, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction) { }
+}
+[System.Diagnostics.DebuggerDisplay("AutoSuspendHelper: {_shouldPersistState}")]
+public sealed class AutoSuspendHelper : Splat.IEnableLogger, System.IDisposable
+{
+    public AutoSuspendHelper(Avalonia.Controls.ApplicationLifetimes.IApplicationLifetime lifetime) { }
+    public void Dispose() { }
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    public void OnFrameworkInitializationCompleted() { }
+}
+public class AvaloniaActivationForViewFetcher : ReactiveUI.IActivationForViewFetcher
+{
+    public AvaloniaActivationForViewFetcher() { }
+    public System.IObservable<bool> GetActivationForView(ReactiveUI.IActivatableView view) { }
+    public int GetAffinityForView(System.Type view) { }
+}
+public static class AvaloniaObjectReactiveExtensions
+{
+    extension(Avalonia.AvaloniaObject o)
+    {
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property) { }
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+        public System.Reactive.Subjects.ISubject<object?> GetSubject(Avalonia.AvaloniaProperty property) { }
+        public System.Reactive.Subjects.ISubject<object?> GetSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public System.Reactive.Subjects.ISubject<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public System.Reactive.Subjects.ISubject<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+    }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControl: {ViewModel}")]
+public class ReactiveUserControl<TViewModel> : ReactiveUI.Avalonia.Reactive.ReactiveUserControlBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveUserControl() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControlBase: {ToString(),nq}")]
+public class ReactiveUserControlBase : Avalonia.Controls.UserControl, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveUserControlBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindow: {ViewModel}")]
+public class ReactiveWindow<TViewModel> : ReactiveUI.Avalonia.Reactive.ReactiveWindowBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveWindow() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindowBase: {ToString(),nq}")]
+public class ReactiveWindowBase : Avalonia.Controls.Window, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveWindowBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("RoutedViewHost: {Router}")]
+public class RoutedViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IActivatableView, Splat.IEnableLogger
+{
+    public RoutedViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<ReactiveUI.Reactive.RoutingState?> RouterProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public object? DefaultContent { get; set; }
+    public ReactiveUI.Reactive.RoutingState? Router { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}
+[System.Diagnostics.DebuggerDisplay("ViewModelViewHost: {ViewModel}")]
+public class ViewModelViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IViewFor, Splat.IEnableLogger
+{
+    public ViewModelViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public static readonly Avalonia.AvaloniaProperty<object?> ViewModelProperty;
+    public object? DefaultContent { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    public object? ViewModel { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}

--- a/src/ReactiveUI.Avalonia.Reactive/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia.Reactive/PublicAPI/net9.0/PublicAPI.txt
@@ -1,0 +1,142 @@
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia")]
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Tests")]
+namespace ReactiveUI.Avalonia.Reactive;
+
+public static class AppBuilderExtensions
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        public Avalonia.AppBuilder RegisterReactiveUIViews(params System.Reflection.Assembly[] assemblies) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromAssemblyOf<TMarker>(params TMarker[] markers) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromEntryAssembly() { }
+        public Avalonia.AppBuilder UseReactiveUI(System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder> withReactiveUIBuilder) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDIContainer<TContainer>(System.Func<TContainer> containerFactory, System.Action<TContainer> containerConfig, System.Func<TContainer, Splat.IDependencyResolver> dependencyResolverFactory, System.Action<ReactiveUI.Reactive.Builder.ReactiveUIBuilder> configureReactiveUI) where TContainer : class { }
+    }
+    extension(ReactiveUI.Reactive.Builder.IReactiveUIBuilder builder)
+    {
+        public ReactiveUI.Reactive.Builder.IReactiveUIBuilder WithAvalonia() { }
+    }
+}
+public class AutoDataTemplateBindingHook : ReactiveUI.IPropertyBindingHook
+{
+    public AutoDataTemplateBindingHook() { }
+    public bool ExecuteHook(object? source, object target, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction) { }
+}
+[System.Diagnostics.DebuggerDisplay("AutoSuspendHelper: {_shouldPersistState}")]
+public sealed class AutoSuspendHelper : Splat.IEnableLogger, System.IDisposable
+{
+    public AutoSuspendHelper(Avalonia.Controls.ApplicationLifetimes.IApplicationLifetime lifetime) { }
+    public void Dispose() { }
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    public void OnFrameworkInitializationCompleted() { }
+}
+public class AvaloniaActivationForViewFetcher : ReactiveUI.IActivationForViewFetcher
+{
+    public AvaloniaActivationForViewFetcher() { }
+    public System.IObservable<bool> GetActivationForView(ReactiveUI.IActivatableView view) { }
+    public int GetAffinityForView(System.Type view) { }
+}
+public static class AvaloniaObjectReactiveExtensions
+{
+    extension(Avalonia.AvaloniaObject o)
+    {
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property) { }
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public System.Reactive.Subjects.ISubject<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+        public System.Reactive.Subjects.ISubject<object?> GetSubject(Avalonia.AvaloniaProperty property) { }
+        public System.Reactive.Subjects.ISubject<object?> GetSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public System.Reactive.Subjects.ISubject<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public System.Reactive.Subjects.ISubject<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+    }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControl: {ViewModel}")]
+public class ReactiveUserControl<TViewModel> : ReactiveUI.Avalonia.Reactive.ReactiveUserControlBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveUserControl() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControlBase: {ToString(),nq}")]
+public class ReactiveUserControlBase : Avalonia.Controls.UserControl, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveUserControlBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindow: {ViewModel}")]
+public class ReactiveWindow<TViewModel> : ReactiveUI.Avalonia.Reactive.ReactiveWindowBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveWindow() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindowBase: {ToString(),nq}")]
+public class ReactiveWindowBase : Avalonia.Controls.Window, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveWindowBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("RoutedViewHost: {Router}")]
+public class RoutedViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IActivatableView, Splat.IEnableLogger
+{
+    public RoutedViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<ReactiveUI.Reactive.RoutingState?> RouterProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public object? DefaultContent { get; set; }
+    public ReactiveUI.Reactive.RoutingState? Router { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}
+[System.Diagnostics.DebuggerDisplay("ViewModelViewHost: {ViewModel}")]
+public class ViewModelViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IViewFor, Splat.IEnableLogger
+{
+    public ViewModelViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public static readonly Avalonia.AvaloniaProperty<object?> ViewModelProperty;
+    public object? DefaultContent { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    public object? ViewModel { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}

--- a/src/ReactiveUI.Avalonia/AppBuilderExtensions.cs
+++ b/src/ReactiveUI.Avalonia/AppBuilderExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
+
 #if REACTIVE_SHIM
 namespace ReactiveUI.Avalonia.Reactive;
 #else
@@ -19,31 +21,31 @@ public static class AppBuilderExtensions
     extension(AppBuilder builder)
     {
         /// <summary>Configures the application to use ReactiveUI with Avalonia.</summary>
-        /// <remarks>
-        /// This method sets up activation, property binding, and command binding. The callback can register additional
-        /// services or modify the ReactiveUI configuration before the application is built.
-        /// </remarks>
         /// <param name="withReactiveUIBuilder">
         /// A callback that receives a ReactiveUI builder for further customization.
         /// </param>
         /// <returns>The application builder instance, enabling further configuration.</returns>
         /// <exception cref="ArgumentNullException">Thrown if the builder or <paramref name="withReactiveUIBuilder"/> is null.</exception>
+        /// <remarks>
+        /// This method sets up activation, property binding, and command binding. The callback can register additional
+        /// services or modify the ReactiveUI configuration before the application is built.
+        /// </remarks>
         public AppBuilder UseReactiveUI(Action<ReactiveUIBuilder> withReactiveUIBuilder)
         {
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(withReactiveUIBuilder);
 
-            return builder.AfterPlatformServicesSetup(_ => ConfigureReactiveUI(withReactiveUIBuilder));
+            return builder.AfterPlatformServicesSetup(_ => StartupConfiguration.ConfigureReactiveUI(withReactiveUIBuilder));
         }
 
         /// <summary>Registers ReactiveUI view types from the specified assemblies.</summary>
+        /// <param name="assemblies">Assemblies containing ReactiveUI view types to register.</param>
+        /// <returns>The application builder instance, enabling further configuration.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the builder is null.</exception>
         /// <remarks>
         /// Call this before the application starts so ReactiveUI views are available for dependency resolution.
         /// Registration runs after platform services have been set up.
         /// </remarks>
-        /// <param name="assemblies">Assemblies containing ReactiveUI view types to register.</param>
-        /// <returns>The application builder instance, enabling further configuration.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if the builder is null.</exception>
         [RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
         [RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
         public AppBuilder RegisterReactiveUIViews(params Assembly[] assemblies)
@@ -51,36 +53,34 @@ public static class AppBuilderExtensions
             ArgumentNullException.ThrowIfNull(builder);
 
             return builder.AfterPlatformServicesSetup(platformBuilder =>
-                RegisterReactiveUIViews(AppLocator.CurrentMutable, assemblies));
+                ViewRegistrar.RegisterViews(AppLocator.CurrentMutable, assemblies));
         }
 
         /// <summary>Registers views found in the assembly containing the specified marker type.</summary>
-        /// <remarks>
-        /// This method scans the assembly of <typeparamref name="TMarker"/> and registers its ReactiveUI views.
-        /// </remarks>
         /// <typeparam name="TMarker">The type identifying the assembly to scan.</typeparam>
         /// <param name="markers">Optional marker values retained for source-compatible generic calls.</param>
         /// <returns>The same <see cref="AppBuilder"/> instance, enabling fluent configuration.</returns>
+        /// <remarks>
+        /// This method scans the assembly of <typeparamref name="TMarker"/> and registers its ReactiveUI views.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
         [RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
         public AppBuilder RegisterReactiveUIViewsFromAssemblyOf<TMarker>(params TMarker[] markers) =>
             builder.RegisterReactiveUIViews(typeof(TMarker).Assembly);
 
         /// <summary>Registers all ReactiveUI view types found in the application's entry assembly.</summary>
+        /// <returns>The same builder, with entry-assembly views registered when an entry assembly is available.</returns>
         /// <remarks>
         /// The entry assembly is discovered during application startup. When it is unavailable, no views are registered.
         /// </remarks>
-        /// <returns>The same builder, with entry-assembly views registered when an entry assembly is available.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
         [RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
         public AppBuilder RegisterReactiveUIViewsFromEntryAssembly() =>
-            RegisterReactiveUIViewsFromEntryAssembly(builder, Assembly.GetEntryAssembly());
+            builder.RegisterReactiveUIViewsFromEntryAssembly(Assembly.GetEntryAssembly());
 
         /// <summary>Configures ReactiveUI with a custom dependency injection container and resolver.</summary>
-        /// <remarks>
-        /// Call this during startup before platform services initialize. The container and dependency resolver are
-        /// registered with the application's service locator.
-        /// </remarks>
         /// <typeparam name="TContainer">The dependency injection container type.</typeparam>
         /// <param name="containerFactory">Creates the dependency injection container.</param>
         /// <param name="containerConfig">Configures the created container.</param>
@@ -88,6 +88,10 @@ public static class AppBuilderExtensions
         /// <param name="configureReactiveUI">An action that configures ReactiveUI options and services.</param>
         /// <returns>The application builder configured with the requested container.</returns>
         /// <exception cref="ArgumentNullException">A required argument is <see langword="null"/>.</exception>
+        /// <remarks>
+        /// Call this during startup before platform services initialize. The container and dependency resolver are
+        /// registered with the application's service locator.
+        /// </remarks>
         public AppBuilder UseReactiveUIWithDIContainer<TContainer>(
                 Func<TContainer> containerFactory,
                 Action<TContainer> containerConfig,
@@ -100,12 +104,24 @@ public static class AppBuilderExtensions
             return builder.UseReactiveUI(configureReactiveUI)
                 .AfterPlatformServicesSetup(platformBuilder =>
                 {
-                    ConfigureReactiveUIDIContainer(
+                    StartupConfiguration.ConfigureReactiveUIDIContainer(
                         AppLocator.CurrentMutable,
                         containerFactory,
                         containerConfig,
                         dependencyResolverFactory);
                 });
+        }
+
+        /// <summary>Registers views from the supplied entry assembly when one is available.</summary>
+        /// <param name="entryAssembly">The entry assembly to scan, or null when no entry assembly is available.</param>
+        /// <returns>The same application builder instance.</returns>
+        [RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        internal AppBuilder RegisterReactiveUIViewsFromEntryAssembly(Assembly? entryAssembly)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            return entryAssembly is null ? builder : builder.RegisterReactiveUIViews(entryAssembly);
         }
     }
 
@@ -113,14 +129,13 @@ public static class AppBuilderExtensions
     /// <param name="builder">The ReactiveUI builder to extend.</param>
     extension(IReactiveUIBuilder builder)
     {
-
         /// <summary>Configures the specified ReactiveUI builder to use Avalonia-specific implementations.</summary>
+        /// <returns>The configured IReactiveUIBuilder instance with Avalonia support enabled.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the builder parameter is null.</exception>
         /// <remarks>
         /// This sets the main-thread and task-pool schedulers and registers Avalonia command-binding and property
         /// observation services.
         /// </remarks>
-        /// <returns>The configured IReactiveUIBuilder instance with Avalonia support enabled.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if the builder parameter is null.</exception>
         public IReactiveUIBuilder WithAvalonia()
         {
             ArgumentNullException.ThrowIfNull(builder);
@@ -137,199 +152,4 @@ public static class AppBuilderExtensions
                 }).WithSuspensionHost<Unit>();
         }
     }
-
-    /// <summary>Configures and builds ReactiveUI after Avalonia platform services are ready.</summary>
-    /// <param name="configureReactiveUI">The application-specific ReactiveUI configuration.</param>
-    internal static void ConfigureReactiveUI(Action<ReactiveUIBuilder> configureReactiveUI)
-    {
-        var rxuiBuilder = RxAppBuilder.CreateReactiveUIBuilder();
-        _ = rxuiBuilder.WithAvalonia();
-
-        configureReactiveUI(rxuiBuilder);
-
-        if (Splat.Builder.AppBuilder.HasBeenBuilt)
-        {
-            return;
-        }
-
-        _ = rxuiBuilder.BuildApp();
-    }
-
-    /// <summary>Configures ReactiveUI with a dependency injection container when a mutable resolver is available.</summary>
-    /// <typeparam name="TContainer">The dependency injection container type.</typeparam>
-    /// <param name="resolver">The mutable resolver used for container registration.</param>
-    /// <param name="containerFactory">The factory used to create the container.</param>
-    /// <param name="containerConfig">The configuration action for the container.</param>
-    /// <param name="dependencyResolverFactory">The factory used to create the dependency resolver.</param>
-    internal static void ConfigureReactiveUIDIContainer<TContainer>(
-        IMutableDependencyResolver? resolver,
-        Func<TContainer> containerFactory,
-        Action<TContainer> containerConfig,
-        Func<TContainer, IDependencyResolver> dependencyResolverFactory)
-        where TContainer : class
-    {
-        if (resolver is null)
-        {
-            return;
-        }
-
-        ArgumentNullException.ThrowIfNull(containerFactory, nameof(containerFactory));
-        ArgumentNullException.ThrowIfNull(containerConfig, nameof(containerConfig));
-        ArgumentNullException.ThrowIfNull(dependencyResolverFactory, nameof(dependencyResolverFactory));
-
-        var container = containerFactory();
-        resolver.RegisterConstant(container);
-        var dependencyResolver = dependencyResolverFactory(container);
-        AppLocator.SetLocator(dependencyResolver);
-        RxSchedulers.MainThreadScheduler = AvaloniaScheduler.Instance;
-        containerConfig(container);
-    }
-
-    /// <summary>Registers views from the supplied entry assembly when one is available.</summary>
-    /// <param name="builder">The Avalonia application builder to extend.</param>
-    /// <param name="entryAssembly">The entry assembly to scan, or null when no entry assembly is available.</param>
-    /// <returns>The same application builder instance.</returns>
-    [RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
-    [RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
-    internal static AppBuilder RegisterReactiveUIViewsFromEntryAssembly(AppBuilder builder, Assembly? entryAssembly)
-    {
-        ArgumentNullException.ThrowIfNull(builder);
-
-        return entryAssembly is null ? builder : builder.RegisterReactiveUIViews(entryAssembly);
-    }
-
-    /// <summary>Registers views with the resolver when both resolver and assemblies are available.</summary>
-    /// <param name="resolver">The resolver to register views into.</param>
-    /// <param name="assemblies">The assemblies to scan.</param>
-    [RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
-    [RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
-    internal static void RegisterReactiveUIViews(IMutableDependencyResolver? resolver, Assembly[]? assemblies)
-    {
-        if (resolver is null || assemblies is null || assemblies.Length == 0)
-        {
-            return;
-        }
-
-        RegisterViewsInternal(resolver, assemblies);
-    }
-
-    /// <summary>Registers all non-abstract, non-interface view types implementing IViewFor{T}.</summary>
-    /// <remarks>
-    /// A view contract attribute supplies the registration contract. Each view is resolved from the service locator or
-    /// created through <see cref="Activator"/>. Duplicate assemblies are ignored.
-    /// </remarks>
-    /// <param name="resolver">The dependency resolver in which the discovered view types will be registered.</param>
-    /// <param name="assemblies">An array of assemblies to scan for view types implementing IViewFor{T}.</param>
-    [RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
-    [RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
-    internal static void RegisterViewsInternal(IMutableDependencyResolver resolver, Assembly[] assemblies)
-    {
-        var uniqueAssemblies = new HashSet<Assembly>();
-        foreach (var assembly in assemblies)
-        {
-            if (!uniqueAssemblies.Add(assembly))
-            {
-                continue;
-            }
-
-            foreach (var viewType in assembly.GetTypes())
-            {
-                if (viewType.IsAbstract || viewType.IsInterface)
-                {
-                    continue;
-                }
-
-                var viewForInterface = FindViewForInterface(viewType);
-                if (viewForInterface is null)
-                {
-                    continue;
-                }
-
-                var viewModelType = viewForInterface.GetGenericArguments()[0];
-                var contract = GetViewContract(viewType);
-                var serviceType = typeof(IViewFor<>).MakeGenericType(viewModelType);
-                resolver.Register(
-                    () => CreateView(viewType),
-                    serviceType,
-                    contract);
-            }
-        }
-    }
-
-    /// <summary>Finds the IViewFor{T} interface implemented by the supplied view type.</summary>
-    /// <param name="viewType">The view type to inspect.</param>
-    /// <returns>The matching IViewFor{T} interface, or null when the type is not a ReactiveUI view.</returns>
-    [RequiresUnreferencedCode("Reads implemented interfaces from runtime view types.")]
-    internal static Type? FindViewForInterface(Type viewType)
-    {
-        foreach (var viewInterface in viewType.GetInterfaces())
-        {
-            if (viewInterface.IsGenericType && viewInterface.GetGenericTypeDefinition() == typeof(IViewFor<>))
-            {
-                return viewInterface;
-            }
-        }
-
-        return null;
-    }
-
-    /// <summary>Reads an optional ViewContract attribute contract value from the view type.</summary>
-    /// <param name="viewType">The view type to inspect.</param>
-    /// <returns>The view contract, or null when no contract is declared.</returns>
-    [RequiresUnreferencedCode("Reads custom attributes and reflected properties from runtime view types.")]
-    internal static string? GetViewContract(Type viewType)
-    {
-        foreach (var attribute in viewType.GetCustomAttributes(true))
-        {
-            var attributeType = attribute.GetType();
-            if (!string.Equals(attributeType.Name, "ViewContractAttribute", StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            var property = attributeType.GetProperty("Contract", BindingFlags.Public | BindingFlags.Instance);
-            return property?.GetValue(attribute) as string;
-        }
-
-        return null;
-    }
-
-    /// <summary>Creates or resolves an instance of the specified view type.</summary>
-    /// <param name="viewType">The view type to create.</param>
-    /// <returns>A resolved or newly-created view instance.</returns>
-    [RequiresUnreferencedCode("Creates runtime-discovered view types by reflection.")]
-    internal static object CreateView(Type viewType)
-    {
-        try
-        {
-            var resolved = AppLocator.Current.GetService(viewType);
-            if (resolved is not null)
-            {
-                return resolved;
-            }
-        }
-        catch (Exception error)
-        {
-            return CreateViewAfterResolutionFailure(viewType, error);
-        }
-
-        return CreateViewWithActivator(viewType);
-    }
-
-    /// <summary>Logs a view resolution failure and falls back to Activator creation.</summary>
-    /// <param name="viewType">The view type to create.</param>
-    /// <param name="error">The service locator error.</param>
-    /// <returns>The created view instance.</returns>
-    internal static object CreateViewAfterResolutionFailure(Type viewType, Exception error)
-    {
-        LogHost.Default.Warn(error, $"Failed to resolve view type '{viewType}' from the service locator. Falling back to Activator.");
-        return CreateViewWithActivator(viewType);
-    }
-
-    /// <summary>Creates a view instance through Activator.</summary>
-    /// <param name="viewType">The view type to create.</param>
-    /// <returns>The created view instance.</returns>
-    internal static object CreateViewWithActivator(Type viewType) =>
-        Activator.CreateInstance(viewType)
-        ?? throw new InvalidOperationException($"Failed to create view type '{viewType}'.");
 }

--- a/src/ReactiveUI.Avalonia/AutoSuspendHelper.cs
+++ b/src/ReactiveUI.Avalonia/AutoSuspendHelper.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
+
 #if REACTIVE_SHIM
 namespace ReactiveUI.Avalonia.Reactive;
 #else
@@ -13,6 +15,7 @@ namespace ReactiveUI.Avalonia;
 /// App.OnFrameworkInitializationCompleted method to signal application launch. This class integrates with ReactiveUI's
 /// RxSuspension system and handles application exit and unhandled exceptions to manage state persistence. It is not
 /// intended for use in design mode, where state persistence is disabled.</remarks>
+[System.Diagnostics.DebuggerDisplay("AutoSuspendHelper: {_shouldPersistState}")]
 public sealed class AutoSuspendHelper : IEnableLogger, IDisposable
 {
     /// <summary>Signals when application state should be persisted.</summary>
@@ -28,13 +31,13 @@ public sealed class AutoSuspendHelper : IEnableLogger, IDisposable
     private readonly IControlledApplicationLifetime? _controlledLifetime;
 
     /// <summary>Initializes a new instance of the <see cref="AutoSuspendHelper"/> class.</summary>
-    /// <remarks>If the application is running in design mode, state persistence is disabled. For supported
-    /// lifetimes, application exit events are wired to enable state persistence. This constructor should be called
-    /// after Avalonia application initialization is completed.</remarks>
     /// <param name="lifetime">The application lifetime object used to determine how application exit and state persistence events are handled.
     /// Must not be null.</param>
     /// <exception cref="NotSupportedException">Thrown if the specified application lifetime type is not supported for detecting application exit events.</exception>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="lifetime"/> is null.</exception>
+    /// <remarks>If the application is running in design mode, state persistence is disabled. For supported
+    /// lifetimes, application exit events are wired to enable state persistence. This constructor should be called
+    /// after Avalonia application initialization is completed.</remarks>
     public AutoSuspendHelper(IApplicationLifetime lifetime)
     {
         RxSuspension.SuspensionHost.IsResuming = Observable.Never<Unit>();
@@ -74,6 +77,7 @@ public sealed class AutoSuspendHelper : IEnableLogger, IDisposable
     /// <remarks>This method should be called once all necessary framework setup is finished and the
     /// application is ready to proceed. It notifies observers that initialization is complete, which may trigger
     /// subsequent application logic. Typically used in application startup routines.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void OnFrameworkInitializationCompleted() => _isLaunchingNew.OnNext(Unit.Default);
 
     /// <summary>Releases all resources used by the current instance.</summary>
@@ -95,15 +99,16 @@ public sealed class AutoSuspendHelper : IEnableLogger, IDisposable
     /// <summary>Handles unhandled process exceptions by invalidating persisted state.</summary>
     /// <param name="sender">The event sender.</param>
     /// <param name="args">The unhandled exception event data.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void OnUnhandledException(object? sender, UnhandledExceptionEventArgs args) =>
         _shouldInvalidateState.OnNext(Unit.Default);
 
     /// <summary>Handles the exit event for a controlled application lifetime, ensuring that any required state persistence actions are completed before shutdown.</summary>
+    /// <param name="sender">The lifetime raising the exit event.</param>
+    /// <param name="args">The application exit arguments.</param>
     /// <remarks>This method blocks until all registered state persistence actions have finished executing. It
     /// should be called during application shutdown to guarantee that state is saved reliably. Calling this method from
     /// a non-shutdown context may result in the application waiting indefinitely.</remarks>
-    /// <param name="sender">The lifetime raising the exit event.</param>
-    /// <param name="args">The application exit arguments.</param>
     private void OnControlledApplicationLifetimeExit(object? sender, ControlledApplicationLifetimeExitEventArgs args)
     {
         this.Log().Debug("Received IControlledApplicationLifetime exit event.");

--- a/src/ReactiveUI.Avalonia/AvaloniaActivationForViewFetcher.cs
+++ b/src/ReactiveUI.Avalonia/AvaloniaActivationForViewFetcher.cs
@@ -33,12 +33,12 @@ public class AvaloniaActivationForViewFetcher : IActivationForViewFetcher
     }
 
     /// <summary>Returns whether the specified control is currently loaded in the visual tree.</summary>
-    /// <remarks>This observable can be used to react to the control's activation and deactivation events,
-    /// such as initializing resources when the control is loaded and cleaning up when it is unloaded. The sequence
-    /// emits distinct values and does not repeat the same state consecutively.</remarks>
     /// <param name="control">The control to monitor for loaded and unloaded state changes. Cannot be null.</param>
     /// <returns>An observable sequence of Boolean values. Emits <see langword="true"/> when the control is loaded, and <see
     /// langword="false"/> when it is unloaded. The sequence only emits values when the state changes.</returns>
+    /// <remarks>This observable can be used to react to the control's activation and deactivation events,
+    /// such as initializing resources when the control is loaded and cleaning up when it is unloaded. The sequence
+    /// emits distinct values and does not repeat the same state consecutively.</remarks>
     private static IObservable<bool> GetActivationForControl(Control control)
     {
         var controlLoaded = Observable
@@ -57,13 +57,13 @@ public class AvaloniaActivationForViewFetcher : IActivationForViewFetcher
     }
 
     /// <summary>Creates an observable sequence that emits activation state changes for the specified visual based on its attachment to the visual tree.</summary>
-    /// <remarks>This method is useful for tracking when a visual becomes active or inactive within the visual
-    /// tree, such as for resource management or UI updates. The returned observable emits distinct state changes and
-    /// does not repeat the same value consecutively.</remarks>
     /// <param name="visual">The visual whose activation state will be monitored. Cannot be null.</param>
     /// <returns>An observable sequence of boolean values indicating the activation state of the visual. Emits <see
     /// langword="true"/> when the visual is attached to the visual tree, and <see langword="false"/> when it is
     /// detached. The sequence only emits when the state changes.</returns>
+    /// <remarks>This method is useful for tracking when a visual becomes active or inactive within the visual
+    /// tree, such as for resource management or UI updates. The returned observable emits distinct state changes and
+    /// does not repeat the same value consecutively.</remarks>
     private static IObservable<bool> GetActivationForVisual(Visual visual)
     {
         var visualLoaded = Observable

--- a/src/ReactiveUI.Avalonia/AvaloniaCreatesCommandBinding.cs
+++ b/src/ReactiveUI.Avalonia/AvaloniaCreatesCommandBinding.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Windows.Input;
 
 #if REACTIVE_SHIM
@@ -25,15 +26,15 @@ internal class AvaloniaCreatesCommandBinding : ICreatesCommandBinding
     private const int CommandSourceAffinity = 10;
 
     /// <summary>Calculates an affinity score indicating how suitable the specified type is for data binding in input scenarios.</summary>
-    /// <remarks>A higher affinity score suggests that the type is more appropriate for binding in input or
-    /// command scenarios. This method provides best-effort support for event-based bindings and prioritizes command
-    /// source types when no event target is present.</remarks>
     /// <typeparam name="T">The type of object to evaluate for binding affinity. Typically an input element or command source.</typeparam>
     /// <param name="hasEventTarget">Indicates whether the binding target has an associated event handler. If <see langword="true"/>, the method
     /// returns a score reflecting event-based binding suitability.</param>
     /// <returns>An integer representing the binding affinity score for the specified type. Returns 0 if the type is not an input
     /// element; returns 6 if the type is an input element with an event target; returns 10 if the type is a command
     /// source input element without an event target.</returns>
+    /// <remarks>A higher affinity score suggests that the type is more appropriate for binding in input or
+    /// command scenarios. This method provides best-effort support for event-based bindings and prioritizes command
+    /// source types when no event target is present.</remarks>
     public int GetAffinityForObject<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.PublicProperties)] T>(
         bool hasEventTarget)
@@ -57,9 +58,6 @@ internal class AvaloniaCreatesCommandBinding : ICreatesCommandBinding
     }
 
     /// <summary>Binds the specified command to the given target object.</summary>
-    /// <remarks>Disposing the returned IDisposable will remove the command binding and stop updates to the
-    /// command parameter. This method is typically used to enable dynamic command parameter updates in UI elements such
-    /// as buttons or menu items.</remarks>
     /// <typeparam name="T">The type of the target object. Must be a class that is both an InputElement and implements ICommandSource.</typeparam>
     /// <param name="command">The command to bind, or null to clear the command on a valid command source.</param>
     /// <param name="target">The command target, or null when no binding should be created.</param>
@@ -67,6 +65,9 @@ internal class AvaloniaCreatesCommandBinding : ICreatesCommandBinding
     /// whenever the observable emits a new value.</param>
     /// <returns>A disposable binding, an empty disposable when clearing a valid command source, or null when no target can be bound.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the target object does not implement both InputElement and ICommandSource.</exception>
+    /// <remarks>Disposing the returned IDisposable will remove the command binding and stop updates to the
+    /// command parameter. This method is typically used to enable dynamic command parameter updates in UI elements such
+    /// as buttons or menu items.</remarks>
     [RequiresUnreferencedCode("String/reflection-based event binding may require members removed by trimming.")]
     public IDisposable? BindCommandToObject<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)] T>(
@@ -112,8 +113,6 @@ internal class AvaloniaCreatesCommandBinding : ICreatesCommandBinding
     }
 
     /// <summary>Binds the specified command to an event on the target object.</summary>
-    /// <remarks>Disposing the returned IDisposable will detach the event handler and unbind the command. This
-    /// method is typically used to enable MVVM-style command binding to UI events.</remarks>
     /// <typeparam name="T">The type of the target object to which the command is bound. Must be a class and an InputElement.</typeparam>
     /// <typeparam name="TEventArgs">The type of the event arguments associated with the event.</typeparam>
     /// <param name="command">The command to execute, or null when no binding should be created.</param>
@@ -123,6 +122,8 @@ internal class AvaloniaCreatesCommandBinding : ICreatesCommandBinding
     /// <returns>An IDisposable instance that can be used to unbind the command from the event. Returns null if binding is
     /// unsuccessful.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the target is not an InputElement, or if the specified event is not found on the target object.</exception>
+    /// <remarks>Disposing the returned IDisposable will detach the event handler and unbind the command. This
+    /// method is typically used to enable MVVM-style command binding to UI events.</remarks>
     [RequiresUnreferencedCode("String/reflection-based event binding may require members removed by trimming.")]
     public IDisposable? BindCommandToObject<T, TEventArgs>(
         ICommand? command,
@@ -147,9 +148,6 @@ internal class AvaloniaCreatesCommandBinding : ICreatesCommandBinding
     }
 
     /// <summary>Binds the specified command to an event on the target object.</summary>
-    /// <remarks>The returned <see cref="IDisposable"/> should be disposed to clean up event subscriptions and
-    /// prevent memory leaks. This method is typically used to facilitate command binding in MVVM scenarios where UI
-    /// events trigger command execution.</remarks>
     /// <typeparam name="T">The type of the target object to which the command is bound. Must be a reference type.</typeparam>
     /// <typeparam name="TEventArgs">The type of the event arguments associated with the event handler. Must derive from <see cref="EventArgs"/>.</typeparam>
     /// <param name="command">The command to execute when the event is raised. If <see langword="null"/>, no command will be executed.</param>
@@ -160,6 +158,10 @@ internal class AvaloniaCreatesCommandBinding : ICreatesCommandBinding
     /// <returns>An <see cref="IDisposable"/> instance that, when disposed, unbinds the command from the event. Returns <see
     /// langword="null"/> if binding could not be established.</returns>
     /// <exception cref="NotImplementedException">Thrown in all cases as the method is not implemented.</exception>
+    /// <remarks>The returned <see cref="IDisposable"/> should be disposed to clean up event subscriptions and
+    /// prevent memory leaks. This method is typically used to facilitate command binding in MVVM scenarios where UI
+    /// events trigger command execution.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public IDisposable? BindCommandToObject<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)] T,
         TEventArgs>(
@@ -172,12 +174,12 @@ internal class AvaloniaCreatesCommandBinding : ICreatesCommandBinding
         where TEventArgs : EventArgs => Disposable.Empty;
 
     /// <summary>Searches the type hierarchy of the specified target for a routed event with the given name.</summary>
-    /// <remarks>This method searches for routed events declared on the target's type and its base types. Use
-    /// this method to locate events such as Button.Click when working with derived types.</remarks>
     /// <param name="target">The object whose type hierarchy is searched for the routed event. Must be an instance of a type derived from
     /// InputElement.</param>
     /// <param name="eventName">The name of the routed event to locate. The comparison is case-sensitive.</param>
     /// <returns>The RoutedEvent instance matching the specified name if found; otherwise, null.</returns>
+    /// <remarks>This method searches for routed events declared on the target's type and its base types. Use
+    /// this method to locate events such as Button.Click when working with derived types.</remarks>
     private static RoutedEvent? FindRoutedEvent(object target, string eventName)
     {
         // Search the type hierarchy so events declared on base classes (e.g., Button.Click on Button
@@ -225,13 +227,13 @@ internal class AvaloniaCreatesCommandBinding : ICreatesCommandBinding
         /// Initializes a new instance of the <see cref="RoutedEventSubscriptionClosure"/> class, subscribing the specified element to.
         /// a routed event and binding the event to a command with an observable command parameter.
         /// </summary>
-        /// <remarks>This constructor attaches an event handler to the specified element for the given
-        /// routed event using bubble routing. The command parameter is dynamically updated based on the observable's
-        /// values. All provided arguments must be non-null; otherwise, an exception may be thrown.</remarks>
         /// <param name="element">The input element to associate with the routed event subscription. Cannot be null.</param>
         /// <param name="routedEvent">The routed event to subscribe to on the specified element. Cannot be null.</param>
         /// <param name="command">The command to execute when the routed event is raised. Cannot be null.</param>
         /// <param name="commandParameter">An observable that provides the parameter to pass to the command when executed. Cannot be null.</param>
+        /// <remarks>This constructor attaches an event handler to the specified element for the given
+        /// routed event using bubble routing. The command parameter is dynamically updated based on the observable's
+        /// values. All provided arguments must be non-null; otherwise, an exception may be thrown.</remarks>
         public RoutedEventSubscriptionClosure(
             InputElement element,
             RoutedEvent routedEvent,
@@ -268,11 +270,11 @@ internal class AvaloniaCreatesCommandBinding : ICreatesCommandBinding
         }
 
         /// <summary>Updates the command parameter and enabled state of the associated input element.</summary>
+        /// <param name="value">The new parameter value to evaluate with the command. Can be null if the command does not require a
+        /// parameter.</param>
         /// <remarks>This method should be called when the command parameter changes to ensure the input
         /// element's enabled state reflects the command's ability to execute. The enabled state is determined by
         /// invoking the command's CanExecute method with the provided parameter.</remarks>
-        /// <param name="value">The new parameter value to evaluate with the command. Can be null if the command does not require a
-        /// parameter.</param>
         private void OnCommandParameterChanged(object? value)
         {
             _lastCommandParameter = value;

--- a/src/ReactiveUI.Avalonia/AvaloniaObjectObservableForProperty.cs
+++ b/src/ReactiveUI.Avalonia/AvaloniaObjectObservableForProperty.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
+
 #if REACTIVE_SHIM
 namespace ReactiveUI.Avalonia.Reactive;
 #else
@@ -18,6 +20,7 @@ internal class AvaloniaObjectObservableForProperty : ICreatesObservableForProper
     private const int AvaloniaPropertyAffinity = 4;
 
     /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [RequiresUnreferencedCode("Uses reflection over runtime types which is not trim- or AOT-safe.")]
     public int GetAffinityForObject(Type type, string propertyName) =>
         GetAffinityForObject(type, propertyName, beforeChanged: false);
@@ -40,6 +43,7 @@ internal class AvaloniaObjectObservableForProperty : ICreatesObservableForProper
     }
 
     /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [RequiresUnreferencedCode("Uses reflection over runtime types which is not trim- or AOT-safe.")]
     public IObservable<IObservedChange<object?, object?>> GetNotificationForProperty(
         object sender,
@@ -48,6 +52,7 @@ internal class AvaloniaObjectObservableForProperty : ICreatesObservableForProper
         GetNotificationForProperty(sender, expression, propertyName, beforeChanged: false, suppressWarnings: false);
 
     /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [RequiresUnreferencedCode("Uses reflection over runtime types which is not trim- or AOT-safe.")]
     public IObservable<IObservedChange<object?, object?>> GetNotificationForProperty(
         object sender,

--- a/src/ReactiveUI.Avalonia/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia/PublicAPI/net10.0/PublicAPI.txt
@@ -1,0 +1,142 @@
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia")]
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Tests")]
+namespace ReactiveUI.Avalonia;
+
+public static class AppBuilderExtensions
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        public Avalonia.AppBuilder RegisterReactiveUIViews(params System.Reflection.Assembly[] assemblies) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromAssemblyOf<TMarker>(params TMarker[] markers) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromEntryAssembly() { }
+        public Avalonia.AppBuilder UseReactiveUI(System.Action<ReactiveUI.Builder.ReactiveUIBuilder> withReactiveUIBuilder) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDIContainer<TContainer>(System.Func<TContainer> containerFactory, System.Action<TContainer> containerConfig, System.Func<TContainer, Splat.IDependencyResolver> dependencyResolverFactory, System.Action<ReactiveUI.Builder.ReactiveUIBuilder> configureReactiveUI) where TContainer : class { }
+    }
+    extension(ReactiveUI.Builder.IReactiveUIBuilder builder)
+    {
+        public ReactiveUI.Builder.IReactiveUIBuilder WithAvalonia() { }
+    }
+}
+public class AutoDataTemplateBindingHook : ReactiveUI.IPropertyBindingHook
+{
+    public AutoDataTemplateBindingHook() { }
+    public bool ExecuteHook(object? source, object target, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction) { }
+}
+[System.Diagnostics.DebuggerDisplay("AutoSuspendHelper: {_shouldPersistState}")]
+public sealed class AutoSuspendHelper : Splat.IEnableLogger, System.IDisposable
+{
+    public AutoSuspendHelper(Avalonia.Controls.ApplicationLifetimes.IApplicationLifetime lifetime) { }
+    public void Dispose() { }
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    public void OnFrameworkInitializationCompleted() { }
+}
+public class AvaloniaActivationForViewFetcher : ReactiveUI.IActivationForViewFetcher
+{
+    public AvaloniaActivationForViewFetcher() { }
+    public System.IObservable<bool> GetActivationForView(ReactiveUI.IActivatableView view) { }
+    public int GetAffinityForView(System.Type view) { }
+}
+public static class AvaloniaObjectReactiveExtensions
+{
+    extension(Avalonia.AvaloniaObject o)
+    {
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+        public ReactiveUI.Primitives.Signals.ISignal<object?> GetSubject(Avalonia.AvaloniaProperty property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<object?> GetSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public ReactiveUI.Primitives.Signals.ISignal<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+    }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControl: {ViewModel}")]
+public class ReactiveUserControl<TViewModel> : ReactiveUI.Avalonia.ReactiveUserControlBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveUserControl() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControlBase: {ToString(),nq}")]
+public class ReactiveUserControlBase : Avalonia.Controls.UserControl, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveUserControlBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindow: {ViewModel}")]
+public class ReactiveWindow<TViewModel> : ReactiveUI.Avalonia.ReactiveWindowBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveWindow() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindowBase: {ToString(),nq}")]
+public class ReactiveWindowBase : Avalonia.Controls.Window, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveWindowBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("RoutedViewHost: {Router}")]
+public class RoutedViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IActivatableView, Splat.IEnableLogger
+{
+    public RoutedViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<ReactiveUI.RoutingState?> RouterProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public object? DefaultContent { get; set; }
+    public ReactiveUI.RoutingState? Router { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}
+[System.Diagnostics.DebuggerDisplay("ViewModelViewHost: {ViewModel}")]
+public class ViewModelViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IViewFor, Splat.IEnableLogger
+{
+    public ViewModelViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public static readonly Avalonia.AvaloniaProperty<object?> ViewModelProperty;
+    public object? DefaultContent { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    public object? ViewModel { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}

--- a/src/ReactiveUI.Avalonia/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia/PublicAPI/net11.0/PublicAPI.txt
@@ -1,0 +1,142 @@
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia")]
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Tests")]
+namespace ReactiveUI.Avalonia;
+
+public static class AppBuilderExtensions
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        public Avalonia.AppBuilder RegisterReactiveUIViews(params System.Reflection.Assembly[] assemblies) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromAssemblyOf<TMarker>(params TMarker[] markers) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromEntryAssembly() { }
+        public Avalonia.AppBuilder UseReactiveUI(System.Action<ReactiveUI.Builder.ReactiveUIBuilder> withReactiveUIBuilder) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDIContainer<TContainer>(System.Func<TContainer> containerFactory, System.Action<TContainer> containerConfig, System.Func<TContainer, Splat.IDependencyResolver> dependencyResolverFactory, System.Action<ReactiveUI.Builder.ReactiveUIBuilder> configureReactiveUI) where TContainer : class { }
+    }
+    extension(ReactiveUI.Builder.IReactiveUIBuilder builder)
+    {
+        public ReactiveUI.Builder.IReactiveUIBuilder WithAvalonia() { }
+    }
+}
+public class AutoDataTemplateBindingHook : ReactiveUI.IPropertyBindingHook
+{
+    public AutoDataTemplateBindingHook() { }
+    public bool ExecuteHook(object? source, object target, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction) { }
+}
+[System.Diagnostics.DebuggerDisplay("AutoSuspendHelper: {_shouldPersistState}")]
+public sealed class AutoSuspendHelper : Splat.IEnableLogger, System.IDisposable
+{
+    public AutoSuspendHelper(Avalonia.Controls.ApplicationLifetimes.IApplicationLifetime lifetime) { }
+    public void Dispose() { }
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    public void OnFrameworkInitializationCompleted() { }
+}
+public class AvaloniaActivationForViewFetcher : ReactiveUI.IActivationForViewFetcher
+{
+    public AvaloniaActivationForViewFetcher() { }
+    public System.IObservable<bool> GetActivationForView(ReactiveUI.IActivatableView view) { }
+    public int GetAffinityForView(System.Type view) { }
+}
+public static class AvaloniaObjectReactiveExtensions
+{
+    extension(Avalonia.AvaloniaObject o)
+    {
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+        public ReactiveUI.Primitives.Signals.ISignal<object?> GetSubject(Avalonia.AvaloniaProperty property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<object?> GetSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public ReactiveUI.Primitives.Signals.ISignal<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+    }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControl: {ViewModel}")]
+public class ReactiveUserControl<TViewModel> : ReactiveUI.Avalonia.ReactiveUserControlBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveUserControl() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControlBase: {ToString(),nq}")]
+public class ReactiveUserControlBase : Avalonia.Controls.UserControl, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveUserControlBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindow: {ViewModel}")]
+public class ReactiveWindow<TViewModel> : ReactiveUI.Avalonia.ReactiveWindowBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveWindow() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindowBase: {ToString(),nq}")]
+public class ReactiveWindowBase : Avalonia.Controls.Window, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveWindowBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("RoutedViewHost: {Router}")]
+public class RoutedViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IActivatableView, Splat.IEnableLogger
+{
+    public RoutedViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<ReactiveUI.RoutingState?> RouterProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public object? DefaultContent { get; set; }
+    public ReactiveUI.RoutingState? Router { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}
+[System.Diagnostics.DebuggerDisplay("ViewModelViewHost: {ViewModel}")]
+public class ViewModelViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IViewFor, Splat.IEnableLogger
+{
+    public ViewModelViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public static readonly Avalonia.AvaloniaProperty<object?> ViewModelProperty;
+    public object? DefaultContent { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    public object? ViewModel { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}

--- a/src/ReactiveUI.Avalonia/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia/PublicAPI/net8.0/PublicAPI.txt
@@ -1,0 +1,142 @@
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia")]
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Tests")]
+namespace ReactiveUI.Avalonia;
+
+public static class AppBuilderExtensions
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        public Avalonia.AppBuilder RegisterReactiveUIViews(params System.Reflection.Assembly[] assemblies) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromAssemblyOf<TMarker>(params TMarker[] markers) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromEntryAssembly() { }
+        public Avalonia.AppBuilder UseReactiveUI(System.Action<ReactiveUI.Builder.ReactiveUIBuilder> withReactiveUIBuilder) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDIContainer<TContainer>(System.Func<TContainer> containerFactory, System.Action<TContainer> containerConfig, System.Func<TContainer, Splat.IDependencyResolver> dependencyResolverFactory, System.Action<ReactiveUI.Builder.ReactiveUIBuilder> configureReactiveUI) where TContainer : class { }
+    }
+    extension(ReactiveUI.Builder.IReactiveUIBuilder builder)
+    {
+        public ReactiveUI.Builder.IReactiveUIBuilder WithAvalonia() { }
+    }
+}
+public class AutoDataTemplateBindingHook : ReactiveUI.IPropertyBindingHook
+{
+    public AutoDataTemplateBindingHook() { }
+    public bool ExecuteHook(object? source, object target, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction) { }
+}
+[System.Diagnostics.DebuggerDisplay("AutoSuspendHelper: {_shouldPersistState}")]
+public sealed class AutoSuspendHelper : Splat.IEnableLogger, System.IDisposable
+{
+    public AutoSuspendHelper(Avalonia.Controls.ApplicationLifetimes.IApplicationLifetime lifetime) { }
+    public void Dispose() { }
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    public void OnFrameworkInitializationCompleted() { }
+}
+public class AvaloniaActivationForViewFetcher : ReactiveUI.IActivationForViewFetcher
+{
+    public AvaloniaActivationForViewFetcher() { }
+    public System.IObservable<bool> GetActivationForView(ReactiveUI.IActivatableView view) { }
+    public int GetAffinityForView(System.Type view) { }
+}
+public static class AvaloniaObjectReactiveExtensions
+{
+    extension(Avalonia.AvaloniaObject o)
+    {
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+        public ReactiveUI.Primitives.Signals.ISignal<object?> GetSubject(Avalonia.AvaloniaProperty property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<object?> GetSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public ReactiveUI.Primitives.Signals.ISignal<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+    }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControl: {ViewModel}")]
+public class ReactiveUserControl<TViewModel> : ReactiveUI.Avalonia.ReactiveUserControlBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveUserControl() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControlBase: {ToString(),nq}")]
+public class ReactiveUserControlBase : Avalonia.Controls.UserControl, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveUserControlBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindow: {ViewModel}")]
+public class ReactiveWindow<TViewModel> : ReactiveUI.Avalonia.ReactiveWindowBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveWindow() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindowBase: {ToString(),nq}")]
+public class ReactiveWindowBase : Avalonia.Controls.Window, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveWindowBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("RoutedViewHost: {Router}")]
+public class RoutedViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IActivatableView, Splat.IEnableLogger
+{
+    public RoutedViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<ReactiveUI.RoutingState?> RouterProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public object? DefaultContent { get; set; }
+    public ReactiveUI.RoutingState? Router { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}
+[System.Diagnostics.DebuggerDisplay("ViewModelViewHost: {ViewModel}")]
+public class ViewModelViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IViewFor, Splat.IEnableLogger
+{
+    public ViewModelViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public static readonly Avalonia.AvaloniaProperty<object?> ViewModelProperty;
+    public object? DefaultContent { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    public object? ViewModel { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}

--- a/src/ReactiveUI.Avalonia/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/ReactiveUI.Avalonia/PublicAPI/net9.0/PublicAPI.txt
@@ -1,0 +1,142 @@
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia")]
+[assembly: Avalonia.Metadata.XmlnsDefinition("http://reactiveui.net", "ReactiveUI.Avalonia.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Autofac.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.DryIoc.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Microsoft.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Ninject.Reactive")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Reactive.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ReactiveUI.Avalonia.Tests")]
+namespace ReactiveUI.Avalonia;
+
+public static class AppBuilderExtensions
+{
+    extension(Avalonia.AppBuilder builder)
+    {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        public Avalonia.AppBuilder RegisterReactiveUIViews(params System.Reflection.Assembly[] assemblies) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromAssemblyOf<TMarker>(params TMarker[] markers) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public Avalonia.AppBuilder RegisterReactiveUIViewsFromEntryAssembly() { }
+        public Avalonia.AppBuilder UseReactiveUI(System.Action<ReactiveUI.Builder.ReactiveUIBuilder> withReactiveUIBuilder) { }
+        public Avalonia.AppBuilder UseReactiveUIWithDIContainer<TContainer>(System.Func<TContainer> containerFactory, System.Action<TContainer> containerConfig, System.Func<TContainer, Splat.IDependencyResolver> dependencyResolverFactory, System.Action<ReactiveUI.Builder.ReactiveUIBuilder> configureReactiveUI) where TContainer : class { }
+    }
+    extension(ReactiveUI.Builder.IReactiveUIBuilder builder)
+    {
+        public ReactiveUI.Builder.IReactiveUIBuilder WithAvalonia() { }
+    }
+}
+public class AutoDataTemplateBindingHook : ReactiveUI.IPropertyBindingHook
+{
+    public AutoDataTemplateBindingHook() { }
+    public bool ExecuteHook(object? source, object target, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewModelProperties, System.Func<ReactiveUI.IObservedChange<object, object>[]> getCurrentViewProperties, ReactiveUI.BindingDirection direction) { }
+}
+[System.Diagnostics.DebuggerDisplay("AutoSuspendHelper: {_shouldPersistState}")]
+public sealed class AutoSuspendHelper : Splat.IEnableLogger, System.IDisposable
+{
+    public AutoSuspendHelper(Avalonia.Controls.ApplicationLifetimes.IApplicationLifetime lifetime) { }
+    public void Dispose() { }
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    public void OnFrameworkInitializationCompleted() { }
+}
+public class AvaloniaActivationForViewFetcher : ReactiveUI.IActivationForViewFetcher
+{
+    public AvaloniaActivationForViewFetcher() { }
+    public System.IObservable<bool> GetActivationForView(ReactiveUI.IActivatableView view) { }
+    public int GetAffinityForView(System.Type view) { }
+}
+public static class AvaloniaObjectReactiveExtensions
+{
+    extension(Avalonia.AvaloniaObject o)
+    {
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<object?>> GetBindingSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<Avalonia.Data.BindingValue<T>> GetBindingSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+        public ReactiveUI.Primitives.Signals.ISignal<object?> GetSubject(Avalonia.AvaloniaProperty property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<object?> GetSubject(Avalonia.AvaloniaProperty property, Avalonia.Data.BindingPriority priority) { }
+        public ReactiveUI.Primitives.Signals.ISignal<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property) { }
+        public ReactiveUI.Primitives.Signals.ISignal<T> GetSubject<T>(Avalonia.AvaloniaProperty<T> property, Avalonia.Data.BindingPriority priority) { }
+    }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControl: {ViewModel}")]
+public class ReactiveUserControl<TViewModel> : ReactiveUI.Avalonia.ReactiveUserControlBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveUserControl() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControlBase: {ToString(),nq}")]
+public class ReactiveUserControlBase : Avalonia.Controls.UserControl, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveUserControlBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindow: {ViewModel}")]
+public class ReactiveWindow<TViewModel> : ReactiveUI.Avalonia.ReactiveWindowBase, ReactiveUI.IViewFor<TViewModel> where TViewModel : class
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    public ReactiveWindow() { }
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    public TViewModel? ViewModel { get; set; }
+    protected override bool IsValidViewModelValue(object? value) { }
+}
+[System.Diagnostics.DebuggerDisplay("ReactiveWindowBase: {ToString(),nq}")]
+public class ReactiveWindowBase : Avalonia.Controls.Window, ReactiveUI.IViewFor
+{
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("ReactiveUI activation evaluates expression-based member chains via reflection; members may be trimmed.")]
+    protected ReactiveWindowBase() { }
+    public static readonly Avalonia.StyledProperty<object?> ViewModelProperty;
+    object? ReactiveUI.IViewFor.ViewModel { get; set; }
+    protected virtual bool IsValidViewModelValue(object? value) { }
+    protected override void OnPropertyChanged(Avalonia.AvaloniaPropertyChangedEventArgs change) { }
+}
+[System.Diagnostics.DebuggerDisplay("RoutedViewHost: {Router}")]
+public class RoutedViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IActivatableView, Splat.IEnableLogger
+{
+    public RoutedViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<ReactiveUI.RoutingState?> RouterProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public object? DefaultContent { get; set; }
+    public ReactiveUI.RoutingState? Router { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}
+[System.Diagnostics.DebuggerDisplay("ViewModelViewHost: {ViewModel}")]
+public class ViewModelViewHost : Avalonia.Controls.TransitioningContentControl, ReactiveUI.IViewFor, Splat.IEnableLogger
+{
+    public ViewModelViewHost() { }
+    public static readonly Avalonia.StyledProperty<object?> DefaultContentProperty;
+    public static readonly Avalonia.StyledProperty<string?> ViewContractProperty;
+    public static readonly Avalonia.AvaloniaProperty<object?> ViewModelProperty;
+    public object? DefaultContent { get; set; }
+    protected override System.Type StyleKeyOverride { get; }
+    public string? ViewContract { get; set; }
+    public ReactiveUI.IViewLocator? ViewLocator { get; set; }
+    public object? ViewModel { get; set; }
+    protected override void OnAttachedToVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+    protected override void OnDetachedFromVisualTree(Avalonia.VisualTreeAttachmentEventArgs e) { }
+}

--- a/src/ReactiveUI.Avalonia/ReactiveUserControl.cs
+++ b/src/ReactiveUI.Avalonia/ReactiveUserControl.cs
@@ -9,6 +9,7 @@ namespace ReactiveUI.Avalonia;
 
 /// <summary>A ReactiveUI <see cref="UserControl"/> that implements <see cref="IViewFor{TViewModel}"/>.</summary>
 /// <typeparam name="TViewModel">ViewModel type.</typeparam>
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControl: {ViewModel}")]
 public class ReactiveUserControl<TViewModel> : ReactiveUserControlBase, IViewFor<TViewModel>
     where TViewModel : class
 {

--- a/src/ReactiveUI.Avalonia/ReactiveUserControlBase.cs
+++ b/src/ReactiveUI.Avalonia/ReactiveUserControlBase.cs
@@ -8,6 +8,7 @@ namespace ReactiveUI.Avalonia;
 #endif
 
 /// <summary>A non-generic ReactiveUI <see cref="UserControl"/> base that owns the Avalonia view model property.</summary>
+[System.Diagnostics.DebuggerDisplay("ReactiveUserControlBase: {ToString(),nq}")]
 public class ReactiveUserControlBase : UserControl, IViewFor
 {
     /// <summary>Identifies the ViewModel dependency property for a ReactiveUserControl.</summary>

--- a/src/ReactiveUI.Avalonia/ReactiveWindow.cs
+++ b/src/ReactiveUI.Avalonia/ReactiveWindow.cs
@@ -9,6 +9,7 @@ namespace ReactiveUI.Avalonia;
 
 /// <summary>A ReactiveUI <see cref="Window"/> that implements <see cref="IViewFor{TViewModel}"/>.</summary>
 /// <typeparam name="TViewModel">ViewModel type.</typeparam>
+[System.Diagnostics.DebuggerDisplay("ReactiveWindow: {ViewModel}")]
 public class ReactiveWindow<TViewModel> : ReactiveWindowBase, IViewFor<TViewModel>
     where TViewModel : class
 {

--- a/src/ReactiveUI.Avalonia/ReactiveWindowBase.cs
+++ b/src/ReactiveUI.Avalonia/ReactiveWindowBase.cs
@@ -8,6 +8,7 @@ namespace ReactiveUI.Avalonia;
 #endif
 
 /// <summary>A non-generic ReactiveUI <see cref="Window"/> base that owns the Avalonia view model property.</summary>
+[System.Diagnostics.DebuggerDisplay("ReactiveWindowBase: {ToString(),nq}")]
 public class ReactiveWindowBase : Window, IViewFor
 {
     /// <summary>Identifies the ViewModel dependency property for a ReactiveWindow.</summary>

--- a/src/ReactiveUI.Avalonia/RoutedViewHost.cs
+++ b/src/ReactiveUI.Avalonia/RoutedViewHost.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
+
 #if REACTIVE_SHIM
 namespace ReactiveUI.Avalonia.Reactive;
 #else
@@ -22,6 +24,7 @@ namespace ReactiveUI.Avalonia;
 /// See <see href="https://reactiveui.net/docs/handbook/routing/">ReactiveUI routing documentation</see>.
 /// </para>
 /// </remarks>
+[System.Diagnostics.DebuggerDisplay("RoutedViewHost: {Router}")]
 public class RoutedViewHost : TransitioningContentControl, IActivatableView, IEnableLogger
 {
     /// <summary>Identifies the Router styled property for the associated RoutedViewHost control.</summary>
@@ -80,12 +83,12 @@ public class RoutedViewHost : TransitioningContentControl, IActivatableView, IEn
     protected override Type StyleKeyOverride => typeof(TransitioningContentControl);
 
     /// <summary>Navigates to the view associated with the specified view model and contract.</summary>
+    /// <param name="viewModel">The view model to display, or null to display the default content.</param>
+    /// <param name="contract">The optional view contract used during resolution.</param>
     /// <remarks>
     /// Missing routers, view models, or views display the default content. A resolved view receives the supplied view
     /// model through both ViewModel and DataContext when supported.
     /// </remarks>
-    /// <param name="viewModel">The view model to display, or null to display the default content.</param>
-    /// <param name="contract">The optional view contract used during resolution.</param>
     internal void NavigateToViewModel(object? viewModel, string? contract)
     {
         if (Router is null)
@@ -159,6 +162,7 @@ public class RoutedViewHost : TransitioningContentControl, IActivatableView, IEn
     /// <summary>Creates a stream that begins with the router's current view model and then follows future navigation.</summary>
     /// <param name="router">The router to observe.</param>
     /// <returns>The current and future routed view models.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static IObservable<object?> CreateRouterViewModelObservable(RoutingState router) =>
         Observable.Return(GetCurrentViewModel(router))
             .Merge(router.CurrentViewModel.Select(static viewModel => (object?)viewModel));
@@ -171,7 +175,7 @@ public class RoutedViewHost : TransitioningContentControl, IActivatableView, IEn
         base.OnAttachedToVisualTree(e);
 
         var disposables = new CompositeDisposable();
-        IObservable<RoutingState?> routerChanges = this.GetObservable(RouterProperty);
+        var routerChanges = this.GetObservable(RouterProperty);
         var viewContract = this.GetObservable(ViewContractProperty);
         var viewModels = routerChanges
             .Select(static router => router is null ? Observable.Return<object?>(null) : CreateRouterViewModelObservable(router))

--- a/src/ReactiveUI.Avalonia/StartupConfiguration.cs
+++ b/src/ReactiveUI.Avalonia/StartupConfiguration.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+#if REACTIVE_SHIM
+namespace ReactiveUI.Avalonia.Reactive;
+#else
+namespace ReactiveUI.Avalonia;
+#endif
+
+/// <summary>Builds ReactiveUI once the Avalonia platform services are ready.</summary>
+/// <remarks>
+/// Avalonia defers these calls until after platform services are set up, so the service locator and the main-thread
+/// scheduler are both available by the time they run.
+/// </remarks>
+internal static class StartupConfiguration
+{
+    /// <summary>Configures and builds ReactiveUI after Avalonia platform services are ready.</summary>
+    /// <param name="configureReactiveUI">The application-specific ReactiveUI configuration.</param>
+    internal static void ConfigureReactiveUI(Action<ReactiveUIBuilder> configureReactiveUI)
+    {
+        var rxuiBuilder = RxAppBuilder.CreateReactiveUIBuilder();
+        _ = rxuiBuilder.WithAvalonia();
+
+        configureReactiveUI(rxuiBuilder);
+
+        if (Splat.Builder.AppBuilder.HasBeenBuilt)
+        {
+            return;
+        }
+
+        _ = rxuiBuilder.BuildApp();
+    }
+
+    /// <summary>Configures ReactiveUI with a dependency injection container when a mutable resolver is available.</summary>
+    /// <typeparam name="TContainer">The dependency injection container type.</typeparam>
+    /// <param name="resolver">The mutable resolver used for container registration.</param>
+    /// <param name="containerFactory">The factory used to create the container.</param>
+    /// <param name="containerConfig">The configuration action for the container.</param>
+    /// <param name="dependencyResolverFactory">The factory used to create the dependency resolver.</param>
+    internal static void ConfigureReactiveUIDIContainer<TContainer>(
+        IMutableDependencyResolver? resolver,
+        Func<TContainer> containerFactory,
+        Action<TContainer> containerConfig,
+        Func<TContainer, IDependencyResolver> dependencyResolverFactory)
+        where TContainer : class
+    {
+        if (resolver is null)
+        {
+            return;
+        }
+
+        ArgumentNullException.ThrowIfNull(containerFactory, nameof(containerFactory));
+        ArgumentNullException.ThrowIfNull(containerConfig, nameof(containerConfig));
+        ArgumentNullException.ThrowIfNull(dependencyResolverFactory, nameof(dependencyResolverFactory));
+
+        var container = containerFactory();
+        resolver.RegisterConstant(container);
+        var dependencyResolver = dependencyResolverFactory(container);
+        AppLocator.SetLocator(dependencyResolver);
+        RxSchedulers.MainThreadScheduler = AvaloniaScheduler.Instance;
+        containerConfig(container);
+    }
+}

--- a/src/ReactiveUI.Avalonia/SubscriptionErrors.cs
+++ b/src/ReactiveUI.Avalonia/SubscriptionErrors.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 
 #if REACTIVE_SHIM
@@ -14,5 +15,6 @@ internal static class SubscriptionErrors
 {
     /// <summary>Rethrows the supplied exception without losing the original stack trace.</summary>
     /// <param name="error">The subscription exception.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void Throw(Exception error) => ExceptionDispatchInfo.Capture(error).Throw();
 }

--- a/src/ReactiveUI.Avalonia/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Avalonia/ViewModelViewHost.cs
@@ -8,6 +8,7 @@ namespace ReactiveUI.Avalonia;
 #endif
 
 /// <summary>Automatically loads and displays the view associated with the ViewModel property.</summary>
+[System.Diagnostics.DebuggerDisplay("ViewModelViewHost: {ViewModel}")]
 public class ViewModelViewHost : TransitioningContentControl, IViewFor, IEnableLogger
 {
     /// <summary>Identifies the ViewModel dependency property for the ViewModelViewHost control.</summary>
@@ -69,12 +70,12 @@ public class ViewModelViewHost : TransitioningContentControl, IViewFor, IEnableL
     protected override Type StyleKeyOverride => typeof(TransitioningContentControl);
 
     /// <summary>Navigates to the view associated with the specified view model and contract.</summary>
+    /// <param name="viewModel">The view model to display, or null to display the default content.</param>
+    /// <param name="contract">The optional contract used to distinguish registered views.</param>
     /// <remarks>
     /// Missing views display the default content. A resolved view receives the supplied view model through ViewModel
     /// and DataContext.
     /// </remarks>
-    /// <param name="viewModel">The view model to display, or null to display the default content.</param>
-    /// <param name="contract">The optional contract used to distinguish registered views.</param>
     internal void NavigateToViewModel(object? viewModel, string? contract)
     {
         if (viewModel is null)

--- a/src/ReactiveUI.Avalonia/ViewRegistrar.cs
+++ b/src/ReactiveUI.Avalonia/ViewRegistrar.cs
@@ -1,0 +1,153 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+#if REACTIVE_SHIM
+namespace ReactiveUI.Avalonia.Reactive;
+#else
+namespace ReactiveUI.Avalonia;
+#endif
+
+/// <summary>Discovers ReactiveUI view types by reflection and registers them with a dependency resolver.</summary>
+/// <remarks>
+/// A view is registered against <c>IViewFor&lt;TViewModel&gt;</c> for the view model it implements, under the contract
+/// its view contract attribute declares. Resolution prefers the service locator and falls back to
+/// <see cref="Activator"/>, so a view with no registration is still constructible.
+/// </remarks>
+internal static class ViewRegistrar
+{
+    /// <summary>Registers views with the resolver when both resolver and assemblies are available.</summary>
+    /// <param name="resolver">The resolver to register into, or null when no mutable resolver is available.</param>
+    /// <param name="assemblies">The assemblies to scan.</param>
+    [RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+    [RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+    internal static void RegisterViews(IMutableDependencyResolver? resolver, Assembly[]? assemblies)
+    {
+        if (resolver is null || assemblies is null || assemblies.Length == 0)
+        {
+            return;
+        }
+
+        RegisterViewsInternal(resolver, assemblies);
+    }
+
+    /// <summary>Registers all non-abstract, non-interface view types implementing IViewFor{T}.</summary>
+    /// <param name="resolver">The resolver to register the discovered views into.</param>
+    /// <param name="assemblies">An array of assemblies to scan for view types implementing IViewFor{T}.</param>
+    /// <remarks>
+    /// A view contract attribute supplies the registration contract. Each view is resolved from the service locator or
+    /// created through <see cref="Activator"/>. Duplicate assemblies are ignored.
+    /// </remarks>
+    [RequiresUnreferencedCode("Scans assemblies and reflects over view types and attributes during ReactiveUI view registration.")]
+    [RequiresDynamicCode("Creates closed generic view service types at runtime during ReactiveUI view registration.")]
+    internal static void RegisterViewsInternal(IMutableDependencyResolver resolver, Assembly[] assemblies)
+    {
+        var uniqueAssemblies = new HashSet<Assembly>();
+        foreach (var assembly in assemblies)
+        {
+            if (!uniqueAssemblies.Add(assembly))
+            {
+                continue;
+            }
+
+            foreach (var viewType in assembly.GetTypes())
+            {
+                if (viewType.IsAbstract || viewType.IsInterface)
+                {
+                    continue;
+                }
+
+                var viewForInterface = FindViewForInterface(viewType);
+                if (viewForInterface is null)
+                {
+                    continue;
+                }
+
+                var viewModelType = viewForInterface.GetGenericArguments()[0];
+                var contract = GetViewContract(viewType);
+                var serviceType = typeof(IViewFor<>).MakeGenericType(viewModelType);
+                resolver.Register(
+                    () => CreateView(viewType),
+                    serviceType,
+                    contract);
+            }
+        }
+    }
+
+    /// <summary>Finds the IViewFor{T} interface implemented by the supplied view type.</summary>
+    /// <param name="viewType">The view type to inspect.</param>
+    /// <returns>The matching IViewFor{T} interface, or null when the type is not a ReactiveUI view.</returns>
+    [RequiresUnreferencedCode("Reads implemented interfaces from runtime view types.")]
+    internal static Type? FindViewForInterface(Type viewType)
+    {
+        foreach (var viewInterface in viewType.GetInterfaces())
+        {
+            if (viewInterface.IsGenericType && viewInterface.GetGenericTypeDefinition() == typeof(IViewFor<>))
+            {
+                return viewInterface;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Reads an optional ViewContract attribute contract value from the view type.</summary>
+    /// <param name="viewType">The view type to inspect.</param>
+    /// <returns>The view contract, or null when no contract is declared.</returns>
+    [RequiresUnreferencedCode("Reads custom attributes and reflected properties from runtime view types.")]
+    internal static string? GetViewContract(Type viewType)
+    {
+        foreach (var attribute in viewType.GetCustomAttributes(true))
+        {
+            var attributeType = attribute.GetType();
+            if (!string.Equals(attributeType.Name, "ViewContractAttribute", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var property = attributeType.GetProperty("Contract", BindingFlags.Public | BindingFlags.Instance);
+            return property?.GetValue(attribute) as string;
+        }
+
+        return null;
+    }
+
+    /// <summary>Creates or resolves an instance of the specified view type.</summary>
+    /// <param name="viewType">The view type to create.</param>
+    /// <returns>A resolved or newly-created view instance.</returns>
+    [RequiresUnreferencedCode("Creates runtime-discovered view types by reflection.")]
+    internal static object CreateView(Type viewType)
+    {
+        try
+        {
+            var resolved = AppLocator.Current.GetService(viewType);
+            if (resolved is not null)
+            {
+                return resolved;
+            }
+        }
+        catch (Exception error)
+        {
+            return CreateViewAfterResolutionFailure(viewType, error);
+        }
+
+        return CreateViewWithActivator(viewType);
+    }
+
+    /// <summary>Logs a view resolution failure and falls back to Activator creation.</summary>
+    /// <param name="viewType">The view type that failed to resolve.</param>
+    /// <param name="error">The service locator error.</param>
+    /// <returns>The created view instance.</returns>
+    internal static object CreateViewAfterResolutionFailure(Type viewType, Exception error)
+    {
+        LogHost.Default.Warn(error, $"Failed to resolve view type '{viewType}' from the service locator. Falling back to Activator.");
+        return CreateViewWithActivator(viewType);
+    }
+
+    /// <summary>Creates a view instance through Activator.</summary>
+    /// <param name="viewType">The view type to create.</param>
+    /// <returns>The created view instance.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when <c>Activator.CreateInstance(viewType)</c> is <see langword="null"/>.</exception>
+    internal static object CreateViewWithActivator(Type viewType) =>
+        Activator.CreateInstance(viewType)
+        ?? throw new InvalidOperationException($"Failed to create view type '{viewType}'.");
+}

--- a/src/Shared/SplatApp.cs
+++ b/src/Shared/SplatApp.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+#if REACTIVE_SHIM
+namespace ReactiveUI.Avalonia.Reactive.Splat;
+#else
+namespace ReactiveUI.Avalonia.Splat;
+#endif
+
+/// <summary>Guards the one-time build of the ReactiveUI Splat application.</summary>
+/// <remarks>
+/// Each dependency injection integration reaches this during Avalonia's post-platform-setup callback. The callback can
+/// run more than once in a process that configures several builders, and the second build would throw, so the guard
+/// makes the call idempotent.
+/// </remarks>
+internal static class SplatApp
+{
+    /// <summary>Builds the ReactiveUI Splat application when it has not already been built.</summary>
+    /// <param name="rxuiBuilder">The ReactiveUI builder.</param>
+    internal static void BuildIfNeeded(IReactiveUIBuilder rxuiBuilder)
+    {
+        if (SplatBuilder.HasBeenBuilt)
+        {
+            return;
+        }
+
+        _ = rxuiBuilder.BuildApp();
+    }
+}

--- a/src/examples/ReactiveUI.Avalonia.Example.Tests/CallerTestExecutor.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example.Tests/CallerTestExecutor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
 using TUnit.Core.Interfaces;
 
 namespace ReactiveUI.Avalonia.Example.Tests;
@@ -9,5 +10,6 @@ namespace ReactiveUI.Avalonia.Example.Tests;
 public sealed class CallerTestExecutor : ITestExecutor
 {
     /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ValueTask ExecuteTest(TestContext context, Func<ValueTask> action) => action();
 }

--- a/src/examples/ReactiveUI.Avalonia.Example.Tests/ExampleAvaloniaTestSession.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example.Tests/ExampleAvaloniaTestSession.cs
@@ -2,6 +2,7 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using Avalonia;
 using Avalonia.Headless;
 
@@ -19,5 +20,6 @@ public static class ExampleAvaloniaTestSession
 
     /// <summary>Uses the production application setup with a headless rendering backend.</summary>
     /// <returns>The configured application builder.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static AppBuilder BuildAvaloniaApp() => Program.BuildAvaloniaApp().UseHeadless(new());
 }

--- a/src/examples/ReactiveUI.Avalonia.Example.Tests/ShowcaseHeadlessTests.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example.Tests/ShowcaseHeadlessTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
@@ -224,9 +225,11 @@ public sealed class ShowcaseHeadlessTests
         internal int ActiveSubscriptions { get; private set; }
 
         /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public MachineSnapshot ReadSnapshot() => MachineSnapshot.Empty;
 
         /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<MachineSnapshot> Watch(TimeSpan interval) => Signal.Create<MachineSnapshot>(observer =>
         {
             ActiveSubscriptions++;
@@ -240,9 +243,11 @@ public sealed class ShowcaseHeadlessTests
         });
 
         /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Dispose() => _samples.Dispose();
 
         /// <summary>Pushes another measurement on the calling thread.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void Publish() => _samples.OnNext(ReadSnapshot());
     }
 }

--- a/src/examples/ReactiveUI.Avalonia.Example.Tests/ShowcaseViewModelTests.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example.Tests/ShowcaseViewModelTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using Avalonia.Threading;
 using ReactiveUI.Avalonia.Example.Models;
@@ -108,9 +109,11 @@ public sealed class ShowcaseViewModelTests
         internal static MachineSnapshot Snapshot => new(DateTimeOffset.UnixEpoch, ProcessorPercent, WorkingSet, ManagedHeap, ThreadCount, "fixed");
 
         /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public MachineSnapshot ReadSnapshot() => Snapshot;
 
         /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<MachineSnapshot> Watch(TimeSpan interval) => Signal.Return(Snapshot);
     }
 }

--- a/src/examples/ReactiveUI.Avalonia.Example/App.axaml.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/App.axaml.cs
@@ -16,6 +16,7 @@ using Splat;
 namespace ReactiveUI.Avalonia.Example;
 
 /// <summary>The example Avalonia application.</summary>
+[System.Diagnostics.DebuggerDisplay("App: {MainWindowFactory}")]
 public sealed class App : Application
 {
     /// <summary>Gets the window factory composed by the desktop entry point.</summary>

--- a/src/examples/ReactiveUI.Avalonia.Example/Models/MachineSnapshot.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Models/MachineSnapshot.cs
@@ -5,6 +5,7 @@
 namespace ReactiveUI.Avalonia.Example.Models;
 
 /// <summary>Represents one local machine measurement sample.</summary>
+[System.Diagnostics.DebuggerDisplay("MachineSnapshot: {CapturedAt}")]
 public sealed record MachineSnapshot
 {
     /// <summary>Initializes a new instance of the <see cref="MachineSnapshot"/> class.</summary>

--- a/src/examples/ReactiveUI.Avalonia.Example/Models/ShowcaseState.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Models/ShowcaseState.cs
@@ -6,4 +6,5 @@ namespace ReactiveUI.Avalonia.Example.Models;
 /// <summary>The small, serializable state restored between desktop sessions.</summary>
 /// <param name="WorkItemText">The command input.</param>
 /// <param name="CpuWarningThreshold">The CPU warning threshold.</param>
+[System.Diagnostics.DebuggerDisplay("ShowcaseState: {ToString(),nq}")]
 public sealed record ShowcaseState(string WorkItemText, double CpuWarningThreshold);

--- a/src/examples/ReactiveUI.Avalonia.Example/Program.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Program.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using ReactiveUI.Avalonia.Example.Services;
@@ -23,6 +24,7 @@ public static class Program
 
     /// <summary>Builds the Avalonia app with ReactiveUI and Microsoft dependency resolver integration.</summary>
     /// <returns>The configured app builder.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [RequiresUnreferencedCode("The desktop showcase uses expression-based ReactiveUI bindings.")]
     [RequiresDynamicCode("The desktop showcase uses dynamic ReactiveUI bindings.")]
     public static AppBuilder BuildAvaloniaApp() =>
@@ -38,6 +40,7 @@ public static class Program
     /// <summary>Creates the main window after application services have been registered.</summary>
     /// <param name="lifetime">The desktop lifetime.</param>
     /// <returns>The initialized desktop window.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when <c>AppLocator.Current.GetService&lt;ILocalMachineMetricsService&gt;()</c> is <see langword="null"/>.</exception>
     [RequiresUnreferencedCode("The window demonstrates expression-based ReactiveUI bindings.")]
     [RequiresDynamicCode("The window demonstrates dynamic ReactiveUI bindings.")]
     private static MainWindow CreateMainWindow(IClassicDesktopStyleApplicationLifetime lifetime)

--- a/src/examples/ReactiveUI.Avalonia.Example/Services/LocalMachineMetricsService.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Services/LocalMachineMetricsService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using ReactiveUI.Avalonia.Example.Models;
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Signals;
@@ -10,6 +11,7 @@ using ReactiveUI.Primitives.Signals;
 namespace ReactiveUI.Avalonia.Example.Services;
 
 /// <summary>Samples process-local measurements from the current machine.</summary>
+[System.Diagnostics.DebuggerDisplay("LocalMachineMetricsService: {_gate}")]
 public sealed class LocalMachineMetricsService : ILocalMachineMetricsService
 {
     /// <summary>The number of bytes in one megabyte.</summary>
@@ -38,10 +40,7 @@ public sealed class LocalMachineMetricsService : ILocalMachineMetricsService
 
     /// <summary>Initializes a new instance of the <see cref="LocalMachineMetricsService"/> class.</summary>
     /// <param name="timeProvider">The time provider.</param>
-    public LocalMachineMetricsService(TimeProvider timeProvider)
-    {
-        _timeProvider = timeProvider;
-    }
+    public LocalMachineMetricsService(TimeProvider timeProvider) => _timeProvider = timeProvider;
 
     /// <inheritdoc/>
     public MachineSnapshot ReadSnapshot()
@@ -60,6 +59,7 @@ public sealed class LocalMachineMetricsService : ILocalMachineMetricsService
     }
 
     /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public IObservable<MachineSnapshot> Watch(TimeSpan interval) =>
         Signal.Interval(interval)
             .StartWith(0L)

--- a/src/examples/ReactiveUI.Avalonia.Example/Services/ShowcaseSession.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Services/ShowcaseSession.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Avalonia.Controls.ApplicationLifetimes;
 using ReactiveUI;
@@ -12,6 +13,7 @@ using ReactiveUI.Primitives.Disposables;
 namespace ReactiveUI.Avalonia.Example.Services;
 
 /// <summary>Composes Avalonia suspension notifications with a small local JSON settings store.</summary>
+[System.Diagnostics.DebuggerDisplay("ShowcaseSession: {_shell}")]
 public sealed class ShowcaseSession : IDisposable
 {
     /// <summary>The view model whose settings are persisted.</summary>
@@ -41,6 +43,7 @@ public sealed class ShowcaseSession : IDisposable
     }
 
     /// <summary>Signals startup after the shell and its services have been composed.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Start() => _suspension.OnFrameworkInitializationCompleted();
 
     /// <inheritdoc/>
@@ -73,6 +76,7 @@ public sealed class ShowcaseSession : IDisposable
     }
 
     /// <summary>Restores the last session or reports a recoverable storage error.</summary>
+    /// <exception cref="JsonException">Thrown when <c>JsonSerializer.Deserialize(File.ReadAllText(_path), ShowcaseJsonContext.Default.ShowcaseState)</c> is <see langword="null"/>.</exception>
     private void Restore()
     {
         try

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/CommandLabViewModel.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/CommandLabViewModel.cs
@@ -10,6 +10,7 @@ using Unit = ReactiveUI.Primitives.RxVoid;
 namespace ReactiveUI.Avalonia.Example.ViewModels;
 
 /// <summary>Demonstrates command can-execute, async execution, failure handling, and interactions.</summary>
+[System.Diagnostics.DebuggerDisplay("CommandLabViewModel: {RunWork}")]
 public sealed class CommandLabViewModel : PageViewModel
 {
     /// <summary>The simulated command work delay.</summary>
@@ -100,6 +101,7 @@ public sealed class CommandLabViewModel : PageViewModel
 
     /// <summary>Intentionally fails to demonstrate command error flow.</summary>
     /// <returns>A task representing the failing work.</returns>
+    /// <exception cref="InvalidOperationException">Always thrown, after the simulated delay.</exception>
     private static async Task FailWorkAsync()
     {
         await Task.Delay(FailureDelay).ConfigureAwait(false);

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/FeatureViewModel.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/FeatureViewModel.cs
@@ -5,4 +5,5 @@ namespace ReactiveUI.Avalonia.Example.ViewModels;
 
 /// <summary>An immutable feature description resolved through an automatic item template.</summary>
 /// <param name="Name">The feature description.</param>
+[System.Diagnostics.DebuggerDisplay("FeatureViewModel: {ToString(),nq}")]
 public sealed record FeatureViewModel(string Name);

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/MainViewModel.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/MainViewModel.cs
@@ -11,6 +11,7 @@ using Unit = ReactiveUI.Primitives.RxVoid;
 namespace ReactiveUI.Avalonia.Example.ViewModels;
 
 /// <summary>Application shell view model.</summary>
+[System.Diagnostics.DebuggerDisplay("MainViewModel: {Router}")]
 public sealed class MainViewModel : ViewModelBase, IScreen
 {
     /// <summary>The overview page.</summary>

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/MetricCardViewModel.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/MetricCardViewModel.cs
@@ -7,6 +7,7 @@ using ReactiveUI;
 namespace ReactiveUI.Avalonia.Example.ViewModels;
 
 /// <summary>View model for a reusable metric card resolved by contract.</summary>
+[System.Diagnostics.DebuggerDisplay("MetricCardViewModel: {Title}")]
 public sealed class MetricCardViewModel : ReactiveObject
 {
     /// <summary>The value text.</summary>

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/MetricsViewModel.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/MetricsViewModel.cs
@@ -12,6 +12,7 @@ using Unit = ReactiveUI.Primitives.RxVoid;
 namespace ReactiveUI.Avalonia.Example.ViewModels;
 
 /// <summary>Shows live local process measurements.</summary>
+[System.Diagnostics.DebuggerDisplay("MetricsViewModel: {ProcessorCard}")]
 public sealed class MetricsViewModel : PageViewModel
 {
     /// <summary>The maximum percentage value.</summary>

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/OverviewViewModel.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/OverviewViewModel.cs
@@ -7,6 +7,7 @@ using ReactiveUI;
 namespace ReactiveUI.Avalonia.Example.ViewModels;
 
 /// <summary>Introduces the showcase features.</summary>
+[System.Diagnostics.DebuggerDisplay("OverviewViewModel: {Features}")]
 public sealed class OverviewViewModel : PageViewModel
 {
     /// <summary>Initializes a new instance of the <see cref="OverviewViewModel"/> class.</summary>

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/PageViewModel.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/PageViewModel.cs
@@ -7,6 +7,7 @@ using ReactiveUI;
 namespace ReactiveUI.Avalonia.Example.ViewModels;
 
 /// <summary>Base routed page view model.</summary>
+[System.Diagnostics.DebuggerDisplay("PageViewModel: {UrlPathSegment}")]
 public class PageViewModel : ViewModelBase, IRoutableViewModel
 {
     /// <summary>Initializes a new instance of the <see cref="PageViewModel"/> class.</summary>

--- a/src/examples/ReactiveUI.Avalonia.Example/ViewModels/ViewModelBase.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/ViewModels/ViewModelBase.cs
@@ -8,13 +8,14 @@ using ReactiveUI.Primitives.Disposables;
 namespace ReactiveUI.Avalonia.Example.ViewModels;
 
 /// <summary>Base view model with ReactiveUI activation support.</summary>
+[System.Diagnostics.DebuggerDisplay("ViewModelBase: {Activator}")]
 public class ViewModelBase : ReactiveObject, IActivatableViewModel, IDisposable
 {
     /// <summary>The disposables owned by the view model.</summary>
     private readonly MultipleDisposable _disposables = new();
 
-    /// <summary>A value indicating whether this instance has been disposed.</summary>
-    private bool _disposed;
+    /// <summary>A latch raised to 1 by the first caller to dispose this instance.</summary>
+    private int _disposed;
 
     /// <summary>Initializes a new instance of the <see cref="ViewModelBase"/> class.</summary>
     protected ViewModelBase() => _disposables.Add(Activator);
@@ -25,12 +26,11 @@ public class ViewModelBase : ReactiveObject, IActivatableViewModel, IDisposable
     /// <inheritdoc/>
     public void Dispose()
     {
-        if (_disposed)
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
         {
             return;
         }
 
-        _disposed = true;
         Dispose(true);
         GC.SuppressFinalize(this);
     }

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/CommandLabView.axaml.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/CommandLabView.axaml.cs
@@ -10,6 +10,7 @@ using Unit = ReactiveUI.Primitives.RxVoid;
 namespace ReactiveUI.Avalonia.Example.Views;
 
 /// <summary>The routed command lab view.</summary>
+[System.Diagnostics.DebuggerDisplay("CommandLabView: {ToString(),nq}")]
 public sealed partial class CommandLabView : ReactiveUserControl<CommandLabViewModel>
 {
     /// <summary>Initializes a new instance of the <see cref="CommandLabView"/> class.</summary>

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/MainWindow.axaml.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/MainWindow.axaml.cs
@@ -3,11 +3,13 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using ReactiveUI.Avalonia.Example.ViewModels;
 
 namespace ReactiveUI.Avalonia.Example.Views;
 
 /// <summary>The main example shell window.</summary>
+[System.Diagnostics.DebuggerDisplay("MainWindow: {ToString(),nq}")]
 public sealed partial class MainWindow : ReactiveWindow<MainViewModel>
 {
     /// <summary>Initializes a new instance of the <see cref="MainWindow"/> class.</summary>
@@ -22,5 +24,6 @@ public sealed partial class MainWindow : ReactiveWindow<MainViewModel>
     /// <summary>Disposes the view model when the shell closes.</summary>
     /// <param name="sender">The event sender.</param>
     /// <param name="e">The event data.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void OnClosed(object? sender, EventArgs e) => ViewModel?.Dispose();
 }

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/MemoryMetricCardView.axaml.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/MemoryMetricCardView.axaml.cs
@@ -12,8 +12,5 @@ public sealed partial class MemoryMetricCardView : ReactiveUserControl<MetricCar
 {
     /// <summary>Initializes a new instance of the <see cref="MemoryMetricCardView"/> class.</summary>
     [RequiresUnreferencedCode("ReactiveUserControl activation evaluates expression-based member chains via reflection.")]
-    public MemoryMetricCardView()
-    {
-        InitializeComponent();
-    }
+    public MemoryMetricCardView() => InitializeComponent();
 }

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/MetricsView.axaml.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/MetricsView.axaml.cs
@@ -12,6 +12,7 @@ using ReactiveUI.Primitives;
 namespace ReactiveUI.Avalonia.Example.Views;
 
 /// <summary>The routed metrics view.</summary>
+[System.Diagnostics.DebuggerDisplay("MetricsView: {ToString(),nq}")]
 public sealed partial class MetricsView : ReactiveUserControl<MetricsViewModel>
 {
     /// <summary>The minimum preview opacity.</summary>

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/OverviewView.axaml.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/OverviewView.axaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using ReactiveUI;
 using ReactiveUI.Avalonia.Example.ViewModels;
 using ReactiveUI.Primitives.Disposables;
@@ -10,6 +11,7 @@ using ReactiveUI.Primitives.Disposables;
 namespace ReactiveUI.Avalonia.Example.Views;
 
 /// <summary>The routed overview view.</summary>
+[System.Diagnostics.DebuggerDisplay("OverviewView: {ToString(),nq}")]
 public sealed partial class OverviewView : ReactiveUserControl<OverviewViewModel>
 {
     /// <summary>Initializes a new instance of the <see cref="OverviewView"/> class.</summary>
@@ -23,6 +25,7 @@ public sealed partial class OverviewView : ReactiveUserControl<OverviewViewModel
 
     /// <summary>Binds items while the overview is active, allowing the automatic template hook to resolve rows.</summary>
     /// <param name="disposables">The current activation lifetime.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [RequiresUnreferencedCode("The feature list uses reflection-based property binding.")]
     [RequiresDynamicCode("The feature list uses dynamic ReactiveUI binding.")]
     private void BindView(MultipleDisposable disposables) =>

--- a/src/examples/ReactiveUI.Avalonia.Example/Views/PerformanceMetricCardView.axaml.cs
+++ b/src/examples/ReactiveUI.Avalonia.Example/Views/PerformanceMetricCardView.axaml.cs
@@ -12,8 +12,5 @@ public sealed partial class PerformanceMetricCardView : ReactiveUserControl<Metr
 {
     /// <summary>Initializes a new instance of the <see cref="PerformanceMetricCardView"/> class.</summary>
     [RequiresUnreferencedCode("ReactiveUserControl activation evaluates expression-based member chains via reflection.")]
-    public PerformanceMetricCardView()
-    {
-        InitializeComponent();
-    }
+    public PerformanceMetricCardView() => InitializeComponent();
 }

--- a/src/tests/.editorconfig
+++ b/src/tests/.editorconfig
@@ -1,0 +1,13 @@
+# Relaxations for the test tree. These projects are not shipped libraries, so a rule written for
+# hot-path production code is noise here. Everything else inherits the repository-root .editorconfig.
+[*.cs]
+
+###################
+# PerformanceSharp (PSH) — relaxed for test projects
+###################
+dotnet_diagnostic.PSH1410.severity = none # A fixture helper is not a hot-path forwarder
+
+###################
+# StyleSharp (SST) — relaxed for test projects
+###################
+dotnet_diagnostic.SST2334.severity = none # Fixtures and models are read through assertions, not a debugger summary

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveCoverageTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveCoverageTests.cs
@@ -284,7 +284,7 @@ public class ReactiveCoverageTests
 
         var configured = false;
         builder = AppBuilder.Configure<Application>().UseReactiveUI(_ => configured = true);
-        AppBuilderExtensions.ConfigureReactiveUI(_ => configured = true);
+        StartupConfiguration.ConfigureReactiveUI(_ => configured = true);
         await Assert.That(configured).IsTrue();
     }
 
@@ -318,7 +318,7 @@ public class ReactiveCoverageTests
     {
         _ = AppBuilder.Configure<Application>()
             .RegisterReactiveUIViews(typeof(RegistrationViewModel).Assembly, typeof(RegistrationViewModel).Assembly);
-        AppBuilderExtensions.RegisterReactiveUIViews(
+        ViewRegistrar.RegisterViews(
             AppLocator.CurrentMutable,
             [typeof(RegistrationViewModel).Assembly, typeof(RegistrationViewModel).Assembly]);
 
@@ -360,7 +360,7 @@ public class ReactiveCoverageTests
                     return new ThrowingResolver();
                 },
                 static _ => { });
-            AppBuilderExtensions.ConfigureReactiveUIDIContainer(
+            StartupConfiguration.ConfigureReactiveUIDIContainer(
                 AppLocator.CurrentMutable,
                 () => MarkFactoryCalled(ref containerFactoryCalled),
                 _ => containerConfigCalled = true,
@@ -386,8 +386,8 @@ public class ReactiveCoverageTests
     {
         _ = AppBuilder.Configure<Application>().RegisterReactiveUIViews((Assembly[]?)null!);
         _ = AppBuilder.Configure<Application>().RegisterReactiveUIViews();
-        AppBuilderExtensions.RegisterReactiveUIViews(AppLocator.CurrentMutable, null);
-        AppBuilderExtensions.RegisterReactiveUIViews(AppLocator.CurrentMutable, []);
+        ViewRegistrar.RegisterViews(AppLocator.CurrentMutable, null);
+        ViewRegistrar.RegisterViews(AppLocator.CurrentMutable, []);
         InvokeRegisterReactiveUIViews(null, [typeof(RegistrationViewModel).Assembly]);
         InvokeRegisterReactiveUIViews(AppLocator.CurrentMutable!, null);
         InvokeRegisterReactiveUIViews(AppLocator.CurrentMutable!, []);
@@ -398,7 +398,7 @@ public class ReactiveCoverageTests
     {
         _ = AppBuilder.Configure<Application>().RegisterReactiveUIViewsFromAssemblyOf<RegistrationViewModel>();
         _ = InvokeRegisterReactiveUIViewsFromAssemblyOf<RegistrationViewModel>(AppBuilder.Configure<Application>());
-        AppBuilderExtensions.RegisterReactiveUIViews(
+        ViewRegistrar.RegisterViews(
             AppLocator.CurrentMutable,
             [typeof(RegistrationViewModel).Assembly]);
     }
@@ -411,7 +411,7 @@ public class ReactiveCoverageTests
         _ = InvokeRegisterReactiveUIViewsFromEntryAssembly(
             AppBuilder.Configure<Application>(),
             typeof(RegistrationViewModel).Assembly);
-        AppBuilderExtensions.RegisterReactiveUIViews(
+        ViewRegistrar.RegisterViews(
             AppLocator.CurrentMutable,
             [typeof(RegistrationViewModel).Assembly]);
     }
@@ -439,7 +439,7 @@ public class ReactiveCoverageTests
     {
         _ = AppBuilder.Configure<Application>()
             .RegisterReactiveUIViews(typeof(RegistrationViewModel).Assembly, typeof(RegistrationViewModel).Assembly);
-        AppBuilderExtensions.RegisterReactiveUIViews(
+        ViewRegistrar.RegisterViews(
             AppLocator.CurrentMutable,
             [typeof(RegistrationViewModel).Assembly, typeof(RegistrationViewModel).Assembly]);
         var serviceType = typeof(IViewFor<>).MakeGenericType(typeof(RegistrationViewModel));
@@ -654,13 +654,13 @@ public class ReactiveCoverageTests
     /// <summary>Invokes the private CreateView fallback path.</summary>
     /// <param name="viewType">The view type.</param>
     /// <returns>The created view.</returns>
-    private static object InvokeCreateView(Type viewType) => AppBuilderExtensions.CreateView(viewType);
+    private static object InvokeCreateView(Type viewType) => ViewRegistrar.CreateView(viewType);
 
     /// <summary>Invokes the private guarded view registration helper.</summary>
     /// <param name="resolver">The resolver to register with.</param>
     /// <param name="assemblies">The assemblies to scan.</param>
     private static void InvokeRegisterReactiveUIViews(IMutableDependencyResolver? resolver, Assembly[]? assemblies) =>
-        AppBuilderExtensions.RegisterReactiveUIViews(resolver, assemblies);
+        ViewRegistrar.RegisterViews(resolver, assemblies);
 
     /// <summary>Invokes the public generic assembly marker registration method through reflection.</summary>
     /// <typeparam name="TMarker">The marker type.</typeparam>
@@ -688,7 +688,7 @@ public class ReactiveCoverageTests
         Action<TContainer> containerConfig,
         Func<TContainer, IDependencyResolver> dependencyResolverFactory)
         where TContainer : class =>
-        AppBuilderExtensions.ConfigureReactiveUIDIContainer(
+        StartupConfiguration.ConfigureReactiveUIDIContainer(
             resolver,
             containerFactory,
             containerConfig,
@@ -1132,10 +1132,7 @@ public class ReactiveCoverageTests
     {
         /// <summary>Initializes a new instance of the <see cref="VmA"/> class.</summary>
         /// <param name="screen">The host screen.</param>
-        public VmA(IScreen screen)
-        {
-            HostScreen = screen;
-        }
+        public VmA(IScreen screen) => HostScreen = screen;
 
         /// <summary>Gets the route path.</summary>
         public string? UrlPathSegment => "a";

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveShimBehaviorCoverageTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveShimBehaviorCoverageTests.cs
@@ -31,7 +31,7 @@ public class ReactiveShimBehaviorCoverageTests
         var untyped = control.GetSubject((AvaloniaProperty)TestControl.IntPropProperty);
         var typed = control.GetSubject(TestControl.IntPropProperty);
         object? untypedObserved = null;
-        int typedObserved = 0;
+        var typedObserved = 0;
 
         using var untypedSubscription = untyped.Subscribe(value => untypedObserved = value);
         using var typedSubscription = typed.Subscribe(value => typedObserved = value);

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveShimFullCoverageTestInfrastructure.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveShimFullCoverageTestInfrastructure.cs
@@ -44,23 +44,23 @@ public partial class ReactiveShimFullCoverageTests
     /// <summary>Invokes the private view factory used by assembly view registration.</summary>
     /// <param name="viewType">The view type to create.</param>
     /// <returns>The created view instance.</returns>
-    private static object InvokePrivateCreateView(Type viewType) => AppBuilderExtensions.CreateView(viewType);
+    private static object InvokePrivateCreateView(Type viewType) => ViewRegistrar.CreateView(viewType);
 
     /// <summary>Invokes the private Activator-based view factory.</summary>
     /// <param name="viewType">The view type to create.</param>
     /// <returns>The created view instance.</returns>
-    private static object InvokePrivateCreateViewWithActivator(Type viewType) => AppBuilderExtensions.CreateViewWithActivator(viewType);
+    private static object InvokePrivateCreateViewWithActivator(Type viewType) => ViewRegistrar.CreateViewWithActivator(viewType);
 
     /// <summary>Invokes the private resolver-failure fallback view factory.</summary>
     /// <param name="viewType">The view type to create.</param>
     /// <returns>The created view instance.</returns>
     private static object InvokePrivateCreateViewAfterResolutionFailure(Type viewType) =>
-        AppBuilderExtensions.CreateViewAfterResolutionFailure(viewType, new InvalidOperationException("expected"));
+        ViewRegistrar.CreateViewAfterResolutionFailure(viewType, new InvalidOperationException("expected"));
 
     /// <summary>Invokes the private view-contract attribute helper.</summary>
     /// <param name="viewType">The view type to inspect.</param>
     /// <returns>The reflected contract value.</returns>
-    private static string? InvokePrivateGetViewContract(Type viewType) => AppBuilderExtensions.GetViewContract(viewType);
+    private static string? InvokePrivateGetViewContract(Type viewType) => ViewRegistrar.GetViewContract(viewType);
 
     /// <summary>Invokes the private entry-assembly view registration helper.</summary>
     /// <param name="builder">The builder instance.</param>
@@ -73,7 +73,7 @@ public partial class ReactiveShimFullCoverageTests
     /// <param name="resolver">The resolver instance.</param>
     /// <param name="assemblies">The assemblies to scan.</param>
     private static void InvokePrivateRegisterReactiveUIViews(IMutableDependencyResolver? resolver, Assembly[]? assemblies) =>
-        AppBuilderExtensions.RegisterReactiveUIViews(resolver, assemblies);
+        ViewRegistrar.RegisterViews(resolver, assemblies);
 
     /// <summary>Invokes the private dependency-injection container helper.</summary>
     /// <typeparam name="TContainer">The container type.</typeparam>
@@ -87,7 +87,7 @@ public partial class ReactiveShimFullCoverageTests
         Action<TContainer> containerConfig,
         Func<TContainer, IDependencyResolver> dependencyResolverFactory)
         where TContainer : class =>
-        AppBuilderExtensions.ConfigureReactiveUIDIContainer(
+        StartupConfiguration.ConfigureReactiveUIDIContainer(
             resolver,
             containerFactory,
             containerConfig,
@@ -389,10 +389,7 @@ public partial class ReactiveShimFullCoverageTests
     {
         /// <summary>Initializes a new instance of the <see cref="VmA"/> class.</summary>
         /// <param name="screen">The host screen.</param>
-        public VmA(ReactiveIScreen screen)
-        {
-            HostScreen = screen;
-        }
+        public VmA(ReactiveIScreen screen) => HostScreen = screen;
 
         /// <summary>Gets the URL path segment.</summary>
         public string? UrlPathSegment => "A";

--- a/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveShimFullCoverageTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Reactive.Tests/ReactiveShimFullCoverageTests.cs
@@ -67,7 +67,7 @@ public partial class ReactiveShimFullCoverageTests
         var result = AppBuilderExtensions.UseReactiveUI(
             builder,
             _ => configured = true);
-        AppBuilderExtensions.ConfigureReactiveUI(_ => configured = true);
+        StartupConfiguration.ConfigureReactiveUI(_ => configured = true);
 
         await Assert.That(result).IsSameReferenceAs(builder);
         await Assert.That(configured).IsTrue();
@@ -86,7 +86,7 @@ public partial class ReactiveShimFullCoverageTests
             AppBuilder.Configure<Application>(),
             typeof(ShimRegistrationVm).Assembly,
             typeof(ShimRegistrationVm).Assembly);
-        AppBuilderExtensions.RegisterReactiveUIViews(
+        ViewRegistrar.RegisterViews(
             AppLocator.CurrentMutable,
             [typeof(ShimRegistrationVm).Assembly, typeof(ShimRegistrationVm).Assembly]);
 
@@ -140,7 +140,7 @@ public partial class ReactiveShimFullCoverageTests
         _ = InvokePrivateRegisterReactiveUIViewsFromEntryAssembly(
             AppBuilder.Configure<Application>(),
             typeof(ShimRegistrationVm).Assembly);
-        AppBuilderExtensions.RegisterReactiveUIViews(
+        ViewRegistrar.RegisterViews(
             AppLocator.CurrentMutable,
             [typeof(ShimRegistrationVm).Assembly]);
         GC.KeepAlive(typeof(NoContractAttributeContainer));
@@ -242,8 +242,8 @@ public partial class ReactiveShimFullCoverageTests
             value => configured = ReferenceEquals(value, container),
             value => ReferenceEquals(value, container) ? resolver : throw new InvalidOperationException(),
             _ => reactiveConfigured = true);
-        AppBuilderExtensions.ConfigureReactiveUI(_ => reactiveConfigured = true);
-        AppBuilderExtensions.ConfigureReactiveUIDIContainer(
+        StartupConfiguration.ConfigureReactiveUI(_ => reactiveConfigured = true);
+        StartupConfiguration.ConfigureReactiveUIDIContainer(
             AppLocator.CurrentMutable,
             () => container,
             value => configured = ReferenceEquals(value, container),
@@ -266,7 +266,7 @@ public partial class ReactiveShimFullCoverageTests
             static _ => { },
             _ => resolver,
             static _ => { });
-        await Assert.That(() => AppBuilderExtensions.ConfigureReactiveUIDIContainer<object>(
+        await Assert.That(() => StartupConfiguration.ConfigureReactiveUIDIContainer<object>(
             AppLocator.CurrentMutable,
             null!,
             static _ => { },
@@ -642,7 +642,7 @@ public partial class ReactiveShimFullCoverageTests
             DefaultContent = DefaultContentValue,
             Router = screen.Router,
             ViewContract = ViewContractValue,
-            ViewLocator = new StaticViewLocator(view, ViewContractValue)
+            ViewLocator = new StaticViewLocator(view, ViewContractValue),
         };
         var vm = new VmA(screen);
 

--- a/src/tests/ReactiveUI.Avalonia.Tests/AppBuilderExtensionsRegistrationTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/AppBuilderExtensionsRegistrationTests.cs
@@ -25,7 +25,7 @@ public class AppBuilderExtensionsRegistrationTests
     {
         var resolver = AppLocator.CurrentMutable!;
         Assembly[] assemblies = [typeof(AppBuilderExtensionsRegistrationTests).Assembly];
-        AppBuilderExtensions.RegisterViewsInternal(resolver, assemblies);
+        ViewRegistrar.RegisterViewsInternal(resolver, assemblies);
 
         var serviceType = typeof(IViewFor<>).MakeGenericType(typeof(TestVm));
         var resolved = AppLocator.Current.GetService(serviceType);
@@ -41,7 +41,7 @@ public class AppBuilderExtensionsRegistrationTests
     {
         var resolver = AppLocator.CurrentMutable!;
         Assembly[] assemblies = [typeof(AppBuilderExtensionsRegistrationTests).Assembly];
-        AppBuilderExtensions.RegisterViewsInternal(resolver, assemblies);
+        ViewRegistrar.RegisterViewsInternal(resolver, assemblies);
 
         var serviceType = typeof(IViewFor<>).MakeGenericType(typeof(TestVm));
         var resolvedDefault = AppLocator.Current.GetService(serviceType);
@@ -59,7 +59,7 @@ public class AppBuilderExtensionsRegistrationTests
     {
         var resolver = AppLocator.CurrentMutable!;
         Assembly[] assemblies = [typeof(AppBuilderExtensionsRegistrationTests).Assembly];
-        AppBuilderExtensions.RegisterViewsInternal(resolver, assemblies);
+        ViewRegistrar.RegisterViewsInternal(resolver, assemblies);
 
         var serviceType = typeof(IViewFor<>).MakeGenericType(typeof(NoContractVm));
         var resolved = AppLocator.Current.GetService(serviceType);
@@ -78,7 +78,7 @@ public class AppBuilderExtensionsRegistrationTests
         resolver.RegisterConstant(resolverBackedView);
 
         Assembly[] assemblies = [typeof(AppBuilderExtensionsRegistrationTests).Assembly];
-        AppBuilderExtensions.RegisterViewsInternal(resolver, assemblies);
+        ViewRegistrar.RegisterViewsInternal(resolver, assemblies);
 
         var serviceType = typeof(IViewFor<>).MakeGenericType(typeof(TestVm));
         var resolved = AppLocator.Current.GetService(serviceType);
@@ -95,7 +95,7 @@ public class AppBuilderExtensionsRegistrationTests
             static () => throw new InvalidOperationException("expected"),
             typeof(FallbackView));
 
-        var resolved = AppBuilderExtensions.CreateView(typeof(FallbackView));
+        var resolved = ViewRegistrar.CreateView(typeof(FallbackView));
 
         await Assert.That(resolved).IsTypeOf<FallbackView>();
     }
@@ -155,7 +155,7 @@ public class AppBuilderExtensionsRegistrationTests
         var builder = AppBuilder.Configure<Application>();
 
         var result = AppBuilderExtensions.RegisterReactiveUIViewsFromEntryAssembly(builder, typeof(AppBuilderExtensionsRegistrationTests).Assembly);
-        AppBuilderExtensions.RegisterReactiveUIViews(AppLocator.CurrentMutable, [typeof(AppBuilderExtensionsRegistrationTests).Assembly]);
+        ViewRegistrar.RegisterViews(AppLocator.CurrentMutable, [typeof(AppBuilderExtensionsRegistrationTests).Assembly]);
 
         var serviceType = typeof(IViewFor<>).MakeGenericType(typeof(DistinctRegistrationVm));
         var resolved = AppLocator.Current.GetService(serviceType);
@@ -171,7 +171,7 @@ public class AppBuilderExtensionsRegistrationTests
     {
         var builder = AppBuilder.Configure<Application>().RegisterReactiveUIViews();
 
-        AppBuilderExtensions.RegisterReactiveUIViews(AppLocator.CurrentMutable, []);
+        ViewRegistrar.RegisterViews(AppLocator.CurrentMutable, []);
 
         await Assert.That(builder).IsNotNull();
     }
@@ -184,9 +184,9 @@ public class AppBuilderExtensionsRegistrationTests
         var resolver = AppLocator.CurrentMutable!;
         var assembly = typeof(AppBuilderExtensionsRegistrationTests).Assembly;
 
-        AppBuilderExtensions.RegisterReactiveUIViews((IMutableDependencyResolver?)null, [assembly]);
-        AppBuilderExtensions.RegisterReactiveUIViews(resolver, null);
-        AppBuilderExtensions.RegisterReactiveUIViews(resolver, []);
+        ViewRegistrar.RegisterViews((IMutableDependencyResolver?)null, [assembly]);
+        ViewRegistrar.RegisterViews(resolver, null);
+        ViewRegistrar.RegisterViews(resolver, []);
 
         await Assert.That(AppLocator.CurrentMutable).IsSameReferenceAs(resolver);
     }
@@ -199,7 +199,7 @@ public class AppBuilderExtensionsRegistrationTests
         _ = AppBuilder.Configure<Application>()
             .RegisterReactiveUIViews(typeof(AppBuilderExtensionsRegistrationTests).Assembly);
 
-        AppBuilderExtensions.RegisterReactiveUIViews(
+        ViewRegistrar.RegisterViews(
             AppLocator.CurrentMutable,
             [typeof(AppBuilderExtensionsRegistrationTests).Assembly]);
 
@@ -220,7 +220,7 @@ public class AppBuilderExtensionsRegistrationTests
         var serviceType = typeof(IViewFor<>).MakeGenericType(typeof(DistinctRegistrationVm));
         var before = CountServices(serviceType);
 
-        AppBuilderExtensions.RegisterViewsInternal(resolver, assemblies);
+        ViewRegistrar.RegisterViewsInternal(resolver, assemblies);
 
         var after = CountServices(serviceType);
         var resolved = AppLocator.Current.GetService(serviceType);
@@ -232,7 +232,7 @@ public class AppBuilderExtensionsRegistrationTests
     /// <summary>Invokes the private CreateView method and preserves the thrown exception type.</summary>
     /// <param name="viewType">The type to create.</param>
     /// <returns>The created view instance.</returns>
-    private static object InvokeCreateView(Type viewType) => AppBuilderExtensions.CreateView(viewType);
+    private static object InvokeCreateView(Type viewType) => ViewRegistrar.CreateView(viewType);
 
     /// <summary>Counts the services registered for a type.</summary>
     /// <param name="serviceType">The registered service type.</param>

--- a/src/tests/ReactiveUI.Avalonia.Tests/AppBuilderExtensionsTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/AppBuilderExtensionsTests.cs
@@ -26,7 +26,7 @@ public class AppBuilderExtensionsTests
     {
         ReactiveUIBuilder.ResetBuilderStateForTests();
         var invoked = false;
-        AppBuilderExtensions.ConfigureReactiveUI(_ => invoked = true);
+        StartupConfiguration.ConfigureReactiveUI(_ => invoked = true);
 
         await Assert.That(invoked).IsTrue();
     }
@@ -37,7 +37,7 @@ public class AppBuilderExtensionsTests
     public async Task UseReactiveUI_AfterPlatformCallback_WhenAlreadyBuilt_ReturnsAfterUserCallback()
     {
         var invoked = false;
-        AppBuilderExtensions.ConfigureReactiveUI(_ => invoked = true);
+        StartupConfiguration.ConfigureReactiveUI(_ => invoked = true);
 
         await Assert.That(invoked).IsTrue();
     }

--- a/src/tests/ReactiveUI.Avalonia.Tests/AppBuilderExtensionsViewsApiTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/AppBuilderExtensionsViewsApiTests.cs
@@ -28,7 +28,7 @@ public class AppBuilderExtensionsViewsApiTests
         await Assert.That(result).IsSameReferenceAs(builder);
 
         var resolver = global::Splat.AppLocator.CurrentMutable!;
-        AppBuilderExtensions.RegisterViewsInternal(resolver, [typeof(AppBuilderExtensionsRegistrationTests).Assembly]);
+        ViewRegistrar.RegisterViewsInternal(resolver, [typeof(AppBuilderExtensionsRegistrationTests).Assembly]);
     }
 
     /// <summary>Verifies that RegisterReactiveUIViewsFromEntryAssembly returns the same builder instance.</summary>

--- a/src/tests/ReactiveUI.Avalonia.Tests/AvaloniaUIThreadTestsMain.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/AvaloniaUIThreadTestsMain.cs
@@ -37,21 +37,12 @@ public class AvaloniaUIThreadTestsMain
     /// <summary>Verifies that AvaloniaScheduler provides the sequencer abstraction used by ReactiveUI.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task AvaloniaScheduler_ImplementsISequencer()
-    {
-        var scheduler = AvaloniaScheduler.Instance;
-        await Assert.That(scheduler).IsAssignableTo<ISequencer>();
-    }
+    public async Task AvaloniaScheduler_ImplementsISequencer() => await Assert.That(AvaloniaScheduler.Instance).IsAssignableTo<ISequencer>();
 
     /// <summary>Verifies that the Timestamp property returns a monotonic timestamp.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task AvaloniaScheduler_Timestamp_ReturnsPositiveValue()
-    {
-        var scheduler = AvaloniaScheduler.Instance;
-
-        await Assert.That(scheduler.Timestamp).IsGreaterThan(0);
-    }
+    public async Task AvaloniaScheduler_Timestamp_ReturnsPositiveValue() => await Assert.That(AvaloniaScheduler.Instance.Timestamp).IsGreaterThan(0);
 
     /// <summary>Verifies that Schedule throws ArgumentNullException for a null work item.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>

--- a/src/tests/ReactiveUI.Avalonia.Tests/DependencyInjectionTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/DependencyInjectionTests.cs
@@ -61,14 +61,9 @@ public class DependencyInjectionTests
     [Test]
     public async Task ReactiveUIAvaloniaNamespace_IsCorrect()
     {
-        var scheduler = typeof(AvaloniaScheduler);
-        await Assert.That(scheduler.Namespace).IsEqualTo("ReactiveUI.Primitives.Concurrency");
-
-        var userControl = typeof(ReactiveUserControl<>);
-        await Assert.That(userControl.Namespace).IsEqualTo("ReactiveUI.Avalonia");
-
-        var window = typeof(ReactiveWindow<>);
-        await Assert.That(window.Namespace).IsEqualTo("ReactiveUI.Avalonia");
+        await Assert.That(typeof(AvaloniaScheduler).Namespace).IsEqualTo("ReactiveUI.Primitives.Concurrency");
+        await Assert.That(typeof(ReactiveUserControl<>).Namespace).IsEqualTo("ReactiveUI.Avalonia");
+        await Assert.That(typeof(ReactiveWindow<>).Namespace).IsEqualTo("ReactiveUI.Avalonia");
     }
 
     /// <summary>Verifies that the assembly has expected metadata.</summary>
@@ -88,17 +83,10 @@ public class DependencyInjectionTests
     [Test]
     public async Task PublicTypes_ArePublic()
     {
-        var scheduler = typeof(AvaloniaScheduler);
-        await Assert.That(scheduler.IsPublic).IsTrue();
-
-        var userControl = typeof(ReactiveUserControl<>);
-        await Assert.That(userControl.IsPublic).IsTrue();
-
-        var window = typeof(ReactiveWindow<>);
-        await Assert.That(window.IsPublic).IsTrue();
-
-        var viewHost = typeof(ViewModelViewHost);
-        await Assert.That(viewHost.IsPublic).IsTrue();
+        await Assert.That(typeof(AvaloniaScheduler).IsPublic).IsTrue();
+        await Assert.That(typeof(ReactiveUserControl<>).IsPublic).IsTrue();
+        await Assert.That(typeof(ReactiveWindow<>).IsPublic).IsTrue();
+        await Assert.That(typeof(ViewModelViewHost).IsPublic).IsTrue();
     }
 
     /// <summary>Verifies that extension method types are public, sealed, and abstract (static).</summary>

--- a/src/tests/ReactiveUI.Avalonia.Tests/ReactiveExtensionsTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/ReactiveExtensionsTests.cs
@@ -24,17 +24,18 @@ public class ReactiveExtensionsTests
     [Test]
     public async Task AvaloniaObjectReactiveExtensions_HasGetSubjectMethod()
     {
-        var type = typeof(AvaloniaObjectReactiveExtensions);
-        var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Static);
+        var methods = typeof(AvaloniaObjectReactiveExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static);
 
         var hasGetSubjectMethod = false;
         foreach (var method in methods)
         {
-            if (method.Name == "GetSubject")
+            if (method.Name != "GetSubject")
             {
-                hasGetSubjectMethod = true;
-                break;
+                continue;
             }
+
+            hasGetSubjectMethod = true;
+            break;
         }
 
         await Assert.That(hasGetSubjectMethod).IsTrue();
@@ -45,17 +46,18 @@ public class ReactiveExtensionsTests
     [Test]
     public async Task AvaloniaObjectReactiveExtensions_HasGetBindingSubjectMethod()
     {
-        var type = typeof(AvaloniaObjectReactiveExtensions);
-        var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Static);
+        var methods = typeof(AvaloniaObjectReactiveExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static);
 
         var hasGetBindingSubjectMethod = false;
         foreach (var method in methods)
         {
-            if (method.Name == "GetBindingSubject")
+            if (method.Name != "GetBindingSubject")
             {
-                hasGetBindingSubjectMethod = true;
-                break;
+                continue;
             }
+
+            hasGetBindingSubjectMethod = true;
+            break;
         }
 
         await Assert.That(hasGetBindingSubjectMethod).IsTrue();
@@ -96,18 +98,19 @@ public class ReactiveExtensionsTests
     [Test]
     public async Task AutoDataTemplateBindingHook_HasExpectedMethods()
     {
-        var type = typeof(AutoDataTemplateBindingHook);
-        var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance);
+        var methods = typeof(AutoDataTemplateBindingHook).GetMethods(BindingFlags.Public | BindingFlags.Instance);
 
         var hasExecuteHookMethod = false;
 
         foreach (var method in methods)
         {
-            if (method.Name == "ExecuteHook")
+            if (method.Name != "ExecuteHook")
             {
-                hasExecuteHookMethod = true;
-                break;
+                continue;
             }
+
+            hasExecuteHookMethod = true;
+            break;
         }
 
         await Assert.That(hasExecuteHookMethod).IsTrue();
@@ -118,8 +121,7 @@ public class ReactiveExtensionsTests
     [Test]
     public async Task AvaloniaActivationForViewFetcher_HasExpectedMethods()
     {
-        var type = typeof(AvaloniaActivationForViewFetcher);
-        var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance);
+        var methods = typeof(AvaloniaActivationForViewFetcher).GetMethods(BindingFlags.Public | BindingFlags.Instance);
 
         var hasGetAffinityForViewMethod = false;
         var hasGetActivationForViewMethod = false;
@@ -145,8 +147,7 @@ public class ReactiveExtensionsTests
     [Test]
     public async Task ReactiveUIAvalonia_HasPublicExtensionMethods()
     {
-        var type = typeof(AvaloniaObjectReactiveExtensions);
-        var publicStaticMethods = type.GetMethods(BindingFlags.Public | BindingFlags.Static);
+        var publicStaticMethods = typeof(AvaloniaObjectReactiveExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static);
 
         await Assert.That(publicStaticMethods.Length).IsGreaterThan(0);
 
@@ -154,11 +155,13 @@ public class ReactiveExtensionsTests
         foreach (var method in publicStaticMethods)
         {
             var extensionAttr = method.GetCustomAttribute<System.Runtime.CompilerServices.ExtensionAttribute>();
-            if (extensionAttr is null)
+            if (extensionAttr is not null)
             {
-                allAreExtensions = false;
-                break;
+                continue;
             }
+
+            allAreExtensions = false;
+            break;
         }
 
         await Assert.That(allAreExtensions).IsTrue();
@@ -184,12 +187,9 @@ public class ReactiveExtensionsTests
     [Test]
     public async Task PublicTypes_HaveParameterlessConstructors()
     {
-        var autoDataTemplateHookType = typeof(AutoDataTemplateBindingHook);
-        var constructors = autoDataTemplateHookType.GetConstructors();
+        var constructors = typeof(AutoDataTemplateBindingHook).GetConstructors();
         await Assert.That(constructors.Length).IsGreaterThan(0);
-
-        var activationFetcherType = typeof(AvaloniaActivationForViewFetcher);
-        var activationConstructors = activationFetcherType.GetConstructors();
+        var activationConstructors = typeof(AvaloniaActivationForViewFetcher).GetConstructors();
         await Assert.That(activationConstructors.Length).IsGreaterThan(0);
     }
 }

--- a/src/tests/ReactiveUI.Avalonia.Tests/UseReactiveUIWithDIContainerTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/UseReactiveUIWithDIContainerTests.cs
@@ -102,7 +102,7 @@ public class UseReactiveUIWithDIContainerTests
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
     public async Task UseReactiveUIWithDIContainer_AfterPlatformCallback_Throws_On_Null_ContainerFactory() =>
-        await Assert.That(static () => AppBuilderExtensions.ConfigureReactiveUIDIContainer<object>(
+        await Assert.That(static () => StartupConfiguration.ConfigureReactiveUIDIContainer<object>(
                 AppLocator.CurrentMutable,
                 containerFactory: null!,
                 containerConfig: static _ => { },
@@ -112,7 +112,7 @@ public class UseReactiveUIWithDIContainerTests
     /// <summary>Verifies that the deferred callback validates a null container config action.</summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
-    public async Task UseReactiveUIWithDIContainer_AfterPlatformCallback_Throws_On_Null_ContainerConfig() => await Assert.That(static () => AppBuilderExtensions.ConfigureReactiveUIDIContainer(
+    public async Task UseReactiveUIWithDIContainer_AfterPlatformCallback_Throws_On_Null_ContainerConfig() => await Assert.That(static () => StartupConfiguration.ConfigureReactiveUIDIContainer(
             AppLocator.CurrentMutable,
             containerFactory: static () => new object(),
             containerConfig: null!,
@@ -122,7 +122,7 @@ public class UseReactiveUIWithDIContainerTests
     /// <returns>A task representing the asynchronous test operation.</returns>
     [Test]
     public async Task UseReactiveUIWithDIContainer_AfterPlatformCallback_Throws_On_Null_DependencyResolverFactory() =>
-        await Assert.That(static () => AppBuilderExtensions.ConfigureReactiveUIDIContainer(
+        await Assert.That(static () => StartupConfiguration.ConfigureReactiveUIDIContainer(
                 AppLocator.CurrentMutable,
                 containerFactory: static () => new object(),
                 containerConfig: static _ => { },
@@ -142,8 +142,8 @@ public class UseReactiveUIWithDIContainerTests
         var configCalled = false;
         var reactiveConfigured = false;
 
-        AppBuilderExtensions.ConfigureReactiveUI(_ => reactiveConfigured = true);
-        AppBuilderExtensions.ConfigureReactiveUIDIContainer(
+        StartupConfiguration.ConfigureReactiveUI(_ => reactiveConfigured = true);
+        StartupConfiguration.ConfigureReactiveUIDIContainer(
             resolver,
             containerFactory: () =>
             {
@@ -172,7 +172,7 @@ public class UseReactiveUIWithDIContainerTests
     {
         var factoryCalled = false;
 
-        AppBuilderExtensions.ConfigureReactiveUIDIContainer(
+        StartupConfiguration.ConfigureReactiveUIDIContainer(
             resolver: null,
             containerFactory: () =>
             {

--- a/src/tests/ReactiveUI.Avalonia.Tests/ViewHostsNavigationTests.cs
+++ b/src/tests/ReactiveUI.Avalonia.Tests/ViewHostsNavigationTests.cs
@@ -670,10 +670,7 @@ public class ViewHostsNavigationTests
     {
         /// <summary>Initializes a new instance of the <see cref="VmA"/> class.</summary>
         /// <param name="screen">The host screen.</param>
-        public VmA(IScreen screen)
-        {
-            HostScreen = screen;
-        }
+        public VmA(IScreen screen) => HostScreen = screen;
 
         /// <summary>Gets the URL path segment.</summary>
         public string? UrlPathSegment => "A";


### PR DESCRIPTION
## What kind of change does this PR introduce?

build

## What is the new behavior?

**Every shipping project checks in its public API surface, and one analyzer family gates the build.**

- Each shipping project tracks its surface as `PublicAPI/<TargetFramework>/PublicAPI.txt`, enforced by `PublicApiSharp.Analyzers`.
- `.editorconfig` configures only the StyleSharp, PerformanceSharp and SecuritySharp rules.
- `src/tests/.editorconfig` relaxes `PSH1410` and `SST2334` for the test tree.
- The second general-purpose analyzer package is out of the build.
- `Verify.TUnit` is out of the build.
- `AppBuilderExtensions` holds only extension blocks, with `StartupConfiguration` and `ViewRegistrar` owning the supporting helpers.
- The dependency injection packages each link one shared copy of the single-build guard from `src/Shared/SplatApp.cs`.
- Library, test and example sources satisfy the enabled rules.
- `ViewModelBase.Dispose` latches through `Interlocked.Exchange`.
- The analyzer packages sit at 4.1.3, `PublicApiSharp.Analyzers` at 1.0.8 and TUnit at 1.67.0, with Avalonia held at 12.1.2.
- `CLAUDE.md` documents the baseline workflow and the analyzer set.
- SonarCloud runs on push and pull request through the shared org workflow.
- CodeQL analyses C# and the workflow files on push, pull request and a weekly schedule.

## What is the current behavior?

The public API surface is untracked, and two general-purpose analyzer families run alongside each other.

## What might this PR break?

Nothing.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
